### PR TITLE
fix logging

### DIFF
--- a/rootfs/usr/local/bin/startup
+++ b/rootfs/usr/local/bin/startup
@@ -61,9 +61,10 @@ EOF
 chown -R vmail:vmail /var/mail/sieve
 sievec /var/mail/sieve/default.sieve
 
-# Logging hardlink
-touch /var/log/mail.log && mkdir /var/log/mail
-ln /var/log/mail.log /var/log/mail/mail.log
+# Logging
+mkdir /var/log/mail && touch /var/log/mail/mail.log
+rm /var/log/mail.log
+ln -s /var/log/mail/mail.log /var/log/mail.log
 
 # Postfix
 if [ -d "$LETS_ENCRYPT_LIVE_PATH" ]; then


### PR DESCRIPTION
C'est tout simple : le but est de faire en sorte que le fichier original soit dans `/var/log/mail`, et de faire un symlink pour que postfix puisse écrire dans `/var/log/mail/mail.log` sans avoir besoin d'une directive... à essayer.