### PR TITLE
fix(): Supervisor socket issue with overlay

### DIFF
--- a/rootfs/etc/supervisor/supervisord.conf
+++ b/rootfs/etc/supervisor/supervisord.conf
@@ -1,5 +1,5 @@
 [unix_http_server]
-file=/var/run/supervisor.sock
+file=/dev/shm/supervisor.sock
 chmod=0700
 
 [supervisord]
@@ -12,7 +12,7 @@ nodaemon=true
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisorctl]
-serverurl=unix:///var/run/supervisor.sock
+serverurl=unix:///dev/shm/supervisor.sock
 
 [include]
 files = /etc/supervisor/conf.d/*.conf

--- a/rootfs/usr/local/bin/startup
+++ b/rootfs/usr/local/bin/startup
@@ -129,5 +129,8 @@ sed -i "s/<FQDN>/${FQDN}/g" /etc/amavis/conf.d/05-node_id
 # Mailname
 sed -i "s/<FQDN>/${FQDN}/g" /etc/mailname
 
+# Supervisor socket
+touch /dev/shm/supervisor.sock
+
 # RUN !
 /usr/bin/supervisord -c /etc/supervisor/supervisord.conf


### PR DESCRIPTION
J'ai finalement trouvé la solution à mon problème, évidemment cela ne pouvait venir qu'une d'une configuration spéciale : j'utilise overlay (fs) avec Docker. 
J'ai trouvé la solution ici : https://github.com/docker/docker/issues/12080#issuecomment-162000092
Le problème est au niveau de overlay et du kernel lui-même, mais ce patch fonctionne, en changeant le chemin du socket de supervisor. J'ai testé, et bien entendu, tout est bon.