### PR TITLE
fix(): reap zombie processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,27 @@
 FROM debian:jessie
 MAINTAINER Hardware <contact@meshup.net>
 
+ENV TINI_VER=0.9.0
+
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     postfix postfix-mysql \
     dovecot-core dovecot-imapd dovecot-lmtpd dovecot-mysql dovecot-sieve dovecot-managesieved \
     opendkim opendkim-tools opendmarc \
     amavisd-new amavisd-milter spamassassin spamc clamav clamav-milter \
     supervisor openssl rsyslog python-pip \
+    wget ca-certificates \
+ && pip install envtpl \
+ && wget -q https://github.com/krallin/tini/releases/download/v$TINI_VER/tini_$TINI_VER.deb -P /tmp \
+ && dpkg -i /tmp/tini_$TINI_VER.deb \
+ && apt-get purge -y \
+    wget \
+    ca-certificates \
+ && apt-get autoremove --purge -y \
  && apt-get clean \
- && rm -rf /var/lib/apt/lists/* \
- && pip install envtpl
+ && rm -rf /tmp/* /var/lib/apt/lists/*
 
 VOLUME /var/mail /var/lib/dovecot /etc/opendkim/keys /etc/letsencrypt
 EXPOSE 25 143 465 587 993 4190
 
 COPY rootfs /
-CMD ["/usr/local/bin/startup"]
+CMD ["tini","--","startup"]


### PR DESCRIPTION
This image should use tini, which is a tiny init for containers, so we can avoid the PID 1 zombie reaping problem inherent to Docker containers.