### PR TITLE
fix(clamav) : Option removed

### DIFF
--- a/rootfs/etc/clamav/clamd.conf
+++ b/rootfs/etc/clamav/clamd.conf
@@ -3,7 +3,7 @@ FixStaleSocket true
 LocalSocketGroup clamav
 LocalSocketMode 666
 User clamav
-AllowSupplementaryGroups true
+#AllowSupplementaryGroups true
 ScanMail true
 ScanArchive true
 ArchiveBlockEncrypted false

--- a/rootfs/etc/clamav/freshclam.conf
+++ b/rootfs/etc/clamav/freshclam.conf
@@ -11,7 +11,7 @@ Debug false
 MaxAttempts 5
 DatabaseDirectory /var/lib/clamav
 DNSDatabaseInfo current.cvd.clamav.net
-AllowSupplementaryGroups false
+#AllowSupplementaryGroups false
 ConnectTimeout 30
 ReceiveTimeout 30
 TestDatabases yes


### PR DESCRIPTION
- AllowSupplementaryGroup is removed (not deprecated), cause fatal error at start