### PR TITLE
Allow using E-mail aliases

### DIFF
--- a/rootfs/etc/postfix/main.cf
+++ b/rootfs/etc/postfix/main.cf
@@ -138,13 +138,13 @@ smtpd_relay_restrictions=
 
 # * reject_non_fqdn_sender : Reject when the MAIL FROM address is not in fully-qualified domain form
 # * reject_unknown_sender_domain : Reject when the MAIL FROM domain has no DNS MX, no DNS A record or a malformed MX record
-# * reject_sender_login_mismatch : Reject when the client is not (SASL) logged in as that MAIL FROM address owner
+# * reject_authenticated_sender_login_mismatch: Reject when the client is not (SASL) logged in as that MAIL FROM address owner for authenticated clients only
 # * reject_rhsbl_sender : Reject when the MAIL FROM domain is blacklisted in dbl.spamhaus.org
 
 smtpd_sender_restrictions=
     reject_non_fqdn_sender,
     reject_unknown_sender_domain,
-    reject_sender_login_mismatch,
+    reject_authenticated_sender_login_mismatch,
     reject_rhsbl_sender dbl.spamhaus.org
 
 ##


### PR DESCRIPTION
Don't know if this change is valid for everyone, but here is my story:

I have email alias viz@linux.com pointing to viz@vizv.email, which is using this project.
I tried to set up my GitLab service using smtp of git@git.vizv.com which is on a vhost of the same server, and sending viz@linux.com a email for testing, but it always fails, but sending to other email addresses works well.

I dig into the problem and found I can't send viz@vizv.email to viz@linux.com, which is pointing to itself. And every time the mail gets rejected with same message `Sender address rejected: not logged in`. I googled around and found someone has exactly the same problem [HERE](http://www.iredmail.org/forum/topic163-iredmail-support-sender-address-rejected-not-logged-in.html), and I realized it is a problem with [`smtpd_sender_restrictions`](http://www.postfix.org/postconf.5.html#smtpd_sender_restrictions).

So I edit the main configuration and everything works.