### PR TITLE
Support to work in UTF8 for SMTP

### DIFF
--- a/rootfs/etc/postfix/main.cf
+++ b/rootfs/etc/postfix/main.cf
@@ -25,6 +25,13 @@ mynetworks    = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
 alias_maps     = hash:/etc/aliases
 alias_database = hash:/etc/aliases
 
+###############
+## SMTP/UTF8 ##
+###############
+
+smtputf8_enable             = yes
+smtputf8_autodetect_classes = all
+
 ###################
 ## RATE LIMITING ##
 ###################


### PR DESCRIPTION
- `smtputf8_enable (default: yes)`
