### PR TITLE
Login dovecot only the active mailbox

### DIFF
--- a/rootfs/etc/dovecot/conf.d/10-mail.conf
+++ b/rootfs/etc/dovecot/conf.d/10-mail.conf
@@ -1,3 +1,4 @@
+mail_plugins = $mail_plugins quota
 mail_location = maildir:/var/mail/vhosts/%d/%n/mail
 maildir_stat_dirs=yes
 

--- a/rootfs/etc/dovecot/conf.d/20-imap.conf
+++ b/rootfs/etc/dovecot/conf.d/20-imap.conf
@@ -2,7 +2,7 @@ imap_idle_notify_interval = 4 mins
 
 protocol imap {
 
-  mail_plugins = $mail_plugins
+  mail_plugins = $mail_plugins imap_quota
   imap_client_workarounds = tb-extra-mailbox-sep
   mail_max_userip_connections = 20
 

--- a/rootfs/etc/dovecot/conf.d/90-quota.conf
+++ b/rootfs/etc/dovecot/conf.d/90-quota.conf
@@ -1,0 +1,21 @@
+plugin {
+
+  quota = maildir:User quota
+  quota_exceeded_message = The quota is exhausted. Contact your system administrator.
+  quota_warning =  storage=90%% quota-warning 90 %u
+  quota_warning2 = storage=80%% quota-warning 80 %u
+  quota_warning3 = storage=70%% quota-warning 70 %u
+  quota_warning4 = storage=60%% quota-warning 60 %u
+
+}
+
+service quota-warning {
+
+   executable = script /usr/local/bin/quota-warning
+   user = vmail
+
+   unix_listener quota-warning {
+     user = vmail
+   }
+
+}

--- a/rootfs/etc/dovecot/dovecot-sql.conf.ext
+++ b/rootfs/etc/dovecot/dovecot-sql.conf.ext
@@ -2,4 +2,5 @@ driver = mysql
 connect = host={{ DBHOST }} dbname={{ DBNAME }} user={{ DBUSER }} password={{ DBPASS }}
 default_pass_scheme = SHA512-CRYPT
 iterate_query = SELECT username AS user FROM mailbox
-password_query = SELECT password FROM mailbox WHERE username = '%u' AND active = 1
+password_query = SELECT password, CONCAT('*:storage=',quota,'B') AS userdb_quota_rule FROM mailbox WHERE username = '%u' AND active = 1
+user_query = SELECT CONCAT('*:storage=',quota,'B') AS quota_rule FROM mailbox WHERE username = '%u' AND active = 1

--- a/rootfs/etc/dovecot/dovecot-sql.conf.ext
+++ b/rootfs/etc/dovecot/dovecot-sql.conf.ext
@@ -1,4 +1,5 @@
 driver = mysql
 connect = host={{ DBHOST }} dbname={{ DBNAME }} user={{ DBUSER }} password={{ DBPASS }}
 default_pass_scheme = SHA512-CRYPT
-password_query = SELECT password FROM mailbox WHERE username = '%u'
+iterate_query = SELECT username AS user FROM mailbox
+password_query = SELECT password FROM mailbox WHERE username = '%u' AND active = 1

--- a/rootfs/usr/local/bin/quota-warning
+++ b/rootfs/usr/local/bin/quota-warning
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+PERCENT=$1
+USER=$2
+
+cat << EOF | /usr/local/libexec/dovecot/dovecot-lda -d $USER -o "plugin/quota=maildir:User quota:noenforcing"
+From: postmaster@{{ DOMAIN }}
+Subject: quota warning
+
+Your mailbox is now $PERCENT% full.
+EOF


### PR DESCRIPTION
Some commands, such as `doveadm -A` need to get a list of users. With SQL userdb this is done with `iterate_query` setting.
