### PR TITLE
Option to pick "gross" as greylisting server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN BUILD_DEPS=" \
     postfix-mysql \
     postfix-pcre \
     postgrey \
+    gross \
     dovecot-core \
     dovecot-imapd \
     dovecot-lmtpd \

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ init:
 		-e DISABLE_CLAMAV=true \
 		-e DISABLE_SPAMASSASSIN=true \
 		-e DISABLE_SIEVE=true \
-		-e ENABLE_POSTGREY=true \
+		-e GREYLISTING=postgrey \
 		-e ENABLE_POP3=true \
 		-e OPENDKIM_KEY_LENGTH=4096 \
 		-e TESTING=true \
@@ -61,8 +61,25 @@ init:
 		-h mail.domain.tld \
 		-t $(NAME)
 
+	docker run \
+		-d \
+		--name mailserver_with_gross \
+		--link mariadb:mariadb \
+		-e DBPASS=testpasswd \
+		-e VMAILUID=`id -u` \
+		-e VMAILGID=`id -g` \
+		-e DISABLE_CLAMAV=true \
+		-e GREYLISTING=gross \
+		-e TESTING=true \
+		-v "`pwd`/test/share/tests":/tmp/tests \
+		-v "`pwd`/test/share/ssl":/var/mail/ssl \
+		-v "`pwd`/test/share/postfix":/var/mail/postfix \
+		-h mail.domain.tld \
+		-t $(NAME)
+
 	docker exec mailserver_default /bin/sh -c "apt-get update && apt-get install -y -q netcat"
 	docker exec mailserver_reverse /bin/sh -c "apt-get update && apt-get install -y -q netcat"
+	docker exec mailserver_with_gross /bin/sh -c "apt-get update && apt-get install -y -q netcat"
 
 fixtures:
 	docker exec mailserver_default /bin/sh -c "nc 0.0.0.0 25 < /tmp/tests/email-templates/external-to-existing-user.txt"
@@ -82,4 +99,4 @@ run:
 	./test/bin/bats test/tests.bats
 
 clean:
-	docker rm -f mariadb mailserver_default mailserver_reverse
+	docker rm -f mariadb mailserver_default mailserver_reverse mailserver_with_gross

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Simple and full-featured mail server as a set of multiple docker images includes
 - **Sieve** : email filtering (vacation auto-responder, auto-forward...etc)
 - **Fetchmail** : fetch e-mails from external IMAP/POP3 server into local mailbox
 - **Postgrey** : greylisting policy server
+- **Gross** : greylisting of suspicious sources
 - **Rainloop** : web based email client
 - **Postfixadmin** : web based administration interface
 - **NSD** : authoritative DNS server with DNSSEC support
@@ -114,12 +115,14 @@ docker logs -f mailserver
 | **DISABLE_CLAMAV** | Disable virus scanning | *optional* | false
 | **DISABLE_SPAMASSASSIN** | Disable SPAM checking | *optional* | false
 | **DISABLE_SIEVE** | Disable ManageSieve protocol | *optional* | false
-| **ENABLE_POSTGREY** | Enable Postgrey greylisting policy server | *optional* | false
+| **GREYLISTING** | Enable greylisting policy server | *optional* | off
 | **ENABLE_POP3** | Enable POP3 protocol | *optional* | false
 | **ENABLE_FETCHMAIL** | Enable fetchmail forwarding | *optional* | false
 | **RECIPIENT_DELIMITER** | RFC 5233 subaddress extension separator (single character only) | *optional* | +
 
 If **DISABLE_CLAMAV** and **DISABLE_SPAMASSASSIN** are both set to **true**, Amavis is also completely disabled.
+
+The supported values for **GREYLISTING** are `off`, `gross` or `postgrey`. Gross is a more advanced greylisting server which blocks only hosts with a bad DNSBL reputation.
 
 Currently, only a single **RECIPIENT_DELIMITER** is supported. Support for multiple delimiters will arrive with Dovecot v2.3.
 
@@ -133,6 +136,8 @@ Currently, only a single **RECIPIENT_DELIMITER** is supported. Support for multi
    ├──postgrey
    │     postgrey.db
    │     ...
+   ├──gross
+   │     grossd.state
    ├──sieve
    │     default.sieve
    │     default.svbin

--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -20,7 +20,7 @@ services:
     environment:
       - DBPASS=xxxxxxx
     # - ENABLE_POP3=true          # Enable POP3 protocol
-    # - ENABLE_POSTGREY=true      # Enable greylisting policy server
+    # - GREYLISTING=gross         # Enable gross greylisting policy server
     # - DISABLE_CLAMAV=true       # Disable virus scanning
     # - DISABLE_SPAMASSASSIN=true # Disable SPAM checking
     # - DISABLE_SIEVE=true        # Disable ManageSieve protocol

--- a/rootfs/etc/grossd.conf
+++ b/rootfs/etc/grossd.conf
@@ -1,0 +1,167 @@
+#
+# This is a sample configuration for grossd
+#
+# This file includes all valid configuration parameters, with their
+# default values. All the default values are commented out, so any 
+# all lines not commented out change the default settings. 
+# 
+# syntax is 
+#
+# name = value [; param]...
+# 
+# you can also add comments after a line 	# this is a comment
+
+
+# 'host' is the address the server should listen for queries
+host = localhost
+
+# 'port' is the port the server should listen for queries
+port = 10023
+
+# 'protocol' activates the server protocols grossd will support
+# Valid protocols are 'sjsms', 'postfix' and 'milter'
+# protocol = sjsms
+protocol = postfix
+
+# 'stat_type' is the name of the requested statistic. There can be multiple
+# 'stat_type' options in the configuration file (Using both none and full is
+# undefined). Default is none. Valid options are currently:
+# full: grossd sends all possible statistics
+# none: no statistics at all
+# status: basic statistics set
+# since_startup: basic set since the startup 
+# delay: processing delay statistics
+# EXAMPLE: stat_type = status
+# EXAMPLE: stat_type = delay
+
+# 'stat_interval' is the number of seconds between status log entries
+# DEFAULT: stat_interval = 3600
+
+# 'filter_bits' is the size of the bloom filter. Size will be 2^filter_bits
+# lowering this value will increase the probability of false matches
+# in each individual bloom filter
+# DEFAULT: filter_bits = 24
+
+# 'number_buffers' is the number of filters used in the ring queue
+# raising this value will cause an entry to stay in the servers' memory longer
+# DEFAULT: number_buffers = 8
+
+# 'rotate_interval' is the number of seconds between filter rotation.
+# Let N := 'number_buffers' and I := 'rotate_interval'. An entry will
+# stay in the servers' memory for (N - 0.5) * I seconds in average. 
+# DEFAULT: rotate_interval = 3600
+
+# 'sync_listen' is the address to listen for communication with the peer
+# defaults to 'host' option
+# sync_listen = 
+
+# 'sync_peer' is the address of the peer used in clustered mode
+# sync_peer = 
+
+# 'sync_port' is the port number to listen to and connect to in 
+# communication with the peer. 
+# DEFAULT: sync_port = 5524
+
+# 'status_host' is the address grossd listens for status queries
+# DEFAULT: status_host = localhost
+
+# 'status_port' is the port number grossd listens for status queries
+# DEFAULT: status_port = 5522
+
+# 'statefile' is the full path of the file that the server will use to
+# store the state information. 
+statefile = /var/mail/gross/grossd.state
+
+# 'pidfile' is the full path of the file grossd writes its pid into.
+# You can set parameter 'check', if you want to keep grossd
+# from starting if pidfile already exists.
+# pidfile = /var/run/grossd.pid;check
+
+# 'log_method' is used to list all the possible logging facilities.
+# currently only syslog is implemented
+# DEFAULT: log_method = syslog
+
+# 'log_level' Possible log levels are 'debug', 'info', 'notice'
+# 'warning' and 'error'.
+# DEFAULT: log_level = info
+
+# 'syslog_facility' is the facility syslog sends log messages with.
+# DEFAULT: syslog_facility = mail
+
+# 'update' is the way server updates the database. Valid options are
+# 'grey' and 'always'. If 'update = grey' grossd will update the database
+# only if response is STATUS_GREY 
+# DEFAULT: update = grey
+
+# 'grey_mask' is the mask for grossd to use when matching client_ip
+# against the database. Default is 24, so grossd treats addresses
+# like a.b.c.d as a.b.c.0. Setting this to 32 makes grossd to 
+# require that consecutive attempts are made from the same ip address.
+# DEFAULT: grey_mask = 24
+
+# 'grey_delay' is the time in seconds new triplets are kept on the greylist.
+# DEFAULT: grey_delay = 10
+
+# 'query_timelimit' is the query timeout in milliseconds.
+# DEFAULT: query_timelimit = 5000
+
+# 'pool_maxthreads' is the maximum threadcount per pool. You may have
+# to raise the limit from the default if you get more than 100 
+# queries per second and/or have slow dns servers. Rule of thumb would be
+# decide how many queries you want grossd to be able to handle per second,
+# and multiply that with query_timelimit (in seconds, of course). 
+# DEFAULT: pool_maxthreads = 100
+
+# 'block_threshold' is the threshold after which grossd sends 
+# a permanent error to the client. Every check that considers client_ip
+# as suspicious returns a value (check weight). When sum of these
+# values gets equivalent or greater than 'block_threshold', grossd
+# sends a STATUS_BLOCK response. Default is 0, which disables
+# this functionality.
+# DEFAULT: block_threshold = 0
+
+# 'block_reason' is the reason given when client is too suspicious,
+# see block_threshold
+# DEFAULT: block_reason = Bad reputation
+
+grey_reason = Shoo shoo! Come back later.
+
+# 'grey_threshold' is analogous to 'block_threshold', except at the 
+# threshold grossd sends a STATUS_GREY response.
+# DEFAULT: grey_threshold = 1
+
+# 'check' lists all the checks grossd will do to judge if client_ip is
+# suspicious or not. 
+check = dnsbl
+#check = rhsbl
+#check = dnswl
+
+# 'dnsbl' is a dns domain name of the dnsbl that 'dnsbl' check will query
+# There are no defaults, but below is a list of dnsbls you could be using
+# you may assign different weights for the dnsbl's, default weight is 1
+# dnsbl = rbl-plus.mail-abuse.net # this is not free
+dnsbl = bl.spamcop.net;2
+dnsbl = combined.njabl.org
+dnsbl = cbl.abuseat.org
+dnsbl = dnsbl.sorbs.net
+
+# 'rhsbl' is analogous to 'dnsbl'
+#rhsbl = rhsbl.sorbs.net
+
+# 'dnswl' is analogous to 'dnsbl'. Remember that dnswl is a *definitive*
+# check, that is grossd waits for the check to complete before deciding
+# how to respond. This may cause unwanted latency. Highly recommended if
+# you use grossd as a traditional greylister.
+#dnswl = query.bondedsender.org 
+
+# 'blocker_host' is the host name of the Sophos blocker server.
+# blocker_host =
+
+# 'blocker_port' is the tcp port of the Sophos blocker service.
+# DEFAULT: blocker_port = 4466
+
+# 'blocker_weight' is the weight of the blocker check. (See description of 'dnsbl')
+# DEFAULT: blocker_weight = 1
+
+# 'milter_listen' is the socket for milter service.
+# EXAMPLE: milter_listen = inet:5523@localhost

--- a/rootfs/etc/postfix/main.cf
+++ b/rootfs/etc/postfix/main.cf
@@ -161,7 +161,7 @@ smtpd_sender_restrictions=
 # * reject_non_fqdn_recipient : Reject when the RCPT TO address is not in fully-qualified domain form
 # * reject_unlisted_recipient : Reject when the RCPT TO address is not listed in the list of valid recipients for its domain
 # * reject_rbl_client : Reject connections from IP addresses blacklisted in zen.spamhaus.org
-# * check_policy_service : Apply greylisting policy with postgrey if RCPT TO domain isn't whitelisted on dnswl.org
+# * check_policy_service : Apply greylisting policy with postgrey/gross if RCPT TO domain isn't whitelisted on dnswl.org
 
 smtpd_recipient_restrictions=
     permit_mynetworks,

--- a/rootfs/etc/supervisor/supervisord.conf
+++ b/rootfs/etc/supervisor/supervisord.conf
@@ -57,6 +57,17 @@ command=/usr/sbin/postgrey --delay=120 --inet=127.0.0.1:10023 --dbdir=/var/mail/
 autostart=false
 autorestart=true
 
+[program:gross_init]
+command=/usr/local/bin/gross
+autostart=true
+autorestart=false
+startsecs=0
+
+[program:gross]
+command=/usr/sbin/grossd -f /etc/grossd.conf -d
+autostart=false
+autorestart=true
+
 [program:spamassassin]
 command=/usr/sbin/spamd --create-prefs --max-children 5 --helper-home-dir
 autostart=false

--- a/rootfs/usr/local/bin/gross
+++ b/rootfs/usr/local/bin/gross
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ "$GREYLISTING" != "gross" ]; then
+  exit 0
+fi
+
+# Create directories and set permissions
+mkdir -p /var/mail/gross && chown -R gross:gross /var/mail/gross
+chmod 700 /var/mail/gross
+
+if [ ! -r /var/mail/gross/grossd.state ]; then
+  /usr/sbin/grossd -f /etc/grossd.conf -C
+fi
+
+# Start gross
+supervisorctl start gross

--- a/rootfs/usr/local/bin/postgrey
+++ b/rootfs/usr/local/bin/postgrey
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$ENABLE_POSTGREY" = false ]; then
+if [ "$GREYLISTING" != "postgrey" ]; then
   exit 0
 fi
 

--- a/rootfs/usr/local/bin/startup
+++ b/rootfs/usr/local/bin/startup
@@ -15,7 +15,7 @@ export FULLCHAIN
 export DISABLE_CLAMAV
 export DISABLE_SPAMASSASSIN
 export DISABLE_SIEVE
-export ENABLE_POSTGREY
+export GREYLISTING
 export ENABLE_POP3
 export ENABLE_FETCHMAIL
 export TESTING
@@ -31,7 +31,7 @@ DBUSER=${DBUSER:-postfix}
 DISABLE_CLAMAV=${DISABLE_CLAMAV:-false}
 DISABLE_SPAMASSASSIN=${DISABLE_SPAMASSASSIN:-false}
 DISABLE_SIEVE=${DISABLE_SIEVE:-false}
-ENABLE_POSTGREY=${ENABLE_POSTGREY:-false}
+GREYLISTING=${GREYLISTING:-off}
 ENABLE_POP3=${ENABLE_POP3:-false}
 ENABLE_FETCHMAIL=${ENABLE_FETCHMAIL:-false}
 TESTING=${TESTING:-false}
@@ -256,11 +256,13 @@ if [ "$DISABLE_CLAMAV" = true ] && [ "$DISABLE_SPAMASSASSIN" = true ]; then
   sed -i '/content_filter/,+1 s/^/#/' /etc/postfix/main.cf
 fi
 
-# Disable Postgrey
-if [ "$ENABLE_POSTGREY" = false ]; then
+# Disable Greylisting
+if [ "$GREYLISTING" = off ]; then
   sed -i '/permit_dnswl_client/,+1 s/^/#/' /etc/postfix/main.cf
-else
+elif [ "$GREYLISTING" = postgrey ]; then
   echo "[INFO] Postgrey is enabled, greylisting policy server will start."
+elif [ "$GREYLISTING" = gross ]; then
+  echo "[INFO] Gross is enabled, greylisting policy server will start."
 fi
 
 # Disable fetchmail forwarding

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -76,6 +76,11 @@
   [ "$status" -eq 1 ]
 }
 
+@test "checking process: gross (disabled in default configuration)" {
+  run docker exec mailserver_default /bin/bash -c "ps aux --forest | grep '[/]usr/sbin/grossd -f /etc/grossd.conf -d'"
+  [ "$status" -eq 1 ]
+}
+
 @test "checking process: spamd (enable in default configuration)" {
   run docker exec mailserver_default /bin/bash -c "ps aux --forest | grep '[/]usr/sbin/spamd --create-prefs --max-children 5 --helper-home-dir'"
   [ "$status" -eq 0 ]
@@ -120,6 +125,11 @@
   [ "$status" -eq 0 ]
 }
 
+@test "checking process: gross (disabled in reverse configuration)" {
+  run docker exec mailserver_default /bin/bash -c "ps aux --forest | grep '[/]usr/sbin/grossd -f /etc/grossd.conf -d'"
+  [ "$status" -eq 1 ]
+}
+
 @test "checking process: spamd (disabled in reverse configuration)" {
   run docker exec mailserver_reverse /bin/bash -c "ps aux --forest | grep '[/]usr/sbin/spamd --create-prefs --max-children 5 --helper-home-dir'"
   [ "$status" -eq 1 ]
@@ -144,6 +154,20 @@
 #   run docker exec mailserver_reverse /bin/bash -c "ps aux --forest | grep '[/]usr/bin/freshclam -d --config-file=/etc/clamav/freshclam.conf'"
 #   [ "$status" -eq 1 ]
 # }
+
+#
+# processes (gross configuration)
+#
+
+@test "checking process: postgrey (disabled in gross configuration)" {
+  run docker exec mailserver_with_gross /bin/bash -c "ps aux --forest | grep '[p]ostgrey --delay=120 --inet=127.0.0.1:10023 --dbdir=/var/mail/postgrey'"
+  [ "$status" -eq 1 ]
+}
+
+@test "checking process: gross (enabled in gross configuration)" {
+  run docker exec mailserver_with_gross /bin/bash -c "ps aux --forest | grep '[/]usr/sbin/grossd -f /etc/grossd.conf -d'"
+  [ "$status" -eq 0 ]
+}
 
 #
 # ports
@@ -256,6 +280,11 @@
 
 @test "checking port (10023): internal port listening (reverse configuration)" {
   run docker exec mailserver_reverse /bin/sh -c "nc -z 127.0.0.1 10023"
+  [ "$status" -eq 0 ]
+}
+
+@test "checking port (10023): internal port listening (gross configuration)" {
+  run docker exec mailserver_with_gross /bin/sh -c "nc -z 127.0.0.1 10023"
   [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
This PR adds option to select between `postgrey` and `gross` as greylistling server. Gross (Greylisting Of Suspicious Sources) only rejects connections from hosts with a bad reputation and therefore allows most legitimate emails to pass on the first attempt.

The current implementation is to include both postgrey and gross into the image on build time and allow the user to pick the desired one with an environment variable. A better approach, though, would be to create dedicated images for both greylisting servers and let `docker-compose` do the job.