### PR TITLE
Fix logging for grossd

### DIFF
--- a/rootfs/etc/supervisor/supervisord.conf
+++ b/rootfs/etc/supervisor/supervisord.conf
@@ -67,6 +67,8 @@ startsecs=0
 command=/usr/sbin/grossd -f /etc/gross/grossd.conf -d
 autostart=false
 autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 
 [program:spamassassin]
 command=/usr/sbin/spamd --create-prefs --max-children 5 --helper-home-dir


### PR DESCRIPTION
This is a little addition to the supervisord configuration to log output of `grossd` properly.