### PR TITLE
Option to specify the mailbox subdirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ docker logs -f mailserver
 | -------- | ----------- | ---- | ------------- |
 | **VMAILUID** | vmail user id | *optional* | 1024
 | **VMAILGID** | vmail group id | *optional* | 1024
+| **VMAIL_SUBDIR** | Individual mailbox' subdirectory | *optional* | mail
 | **OPENDKIM_KEY_LENGTH** | Size of your DKIM RSA key pair | *optional* | 2048
 | **DBHOST** | MariaDB instance ip/hostname | *optional* | mariadb
 | **DBUSER** | MariaDB database username | *optional* | postfix

--- a/rootfs/etc/cron.d/spamassassin
+++ b/rootfs/etc/cron.d/spamassassin
@@ -1,2 +1,2 @@
-30 02 * * * root /usr/bin/sa-learn --ham /var/mail/vhosts/*/*/mail/cur/* | logger -t sa-learn-ham
-40 02 * * * root /usr/bin/sa-learn --spam /var/mail/vhosts/*/*/mail/.Spam/cur/* | logger -t sa-learn-spam
+30 02 * * * root /usr/bin/sa-learn --ham /var/mail/vhosts/*/*/{{ VMAIL_SUBDIR }}/cur/* | logger -t sa-learn-ham
+40 02 * * * root /usr/bin/sa-learn --spam /var/mail/vhosts/*/*/{{ VMAIL_SUBDIR }}/.Spam/cur/* | logger -t sa-learn-spam

--- a/rootfs/etc/dovecot/conf.d/10-mail.conf
+++ b/rootfs/etc/dovecot/conf.d/10-mail.conf
@@ -1,5 +1,5 @@
 mail_plugins = $mail_plugins quota
-mail_location = maildir:/var/mail/vhosts/%d/%n/mail
+mail_location = maildir:/var/mail/vhosts/%d/%n/{{ VMAIL_SUBDIR }}
 maildir_stat_dirs=yes
 
 namespace inbox {

--- a/rootfs/etc/dovecot/dovecot-sql.conf.ext
+++ b/rootfs/etc/dovecot/dovecot-sql.conf.ext
@@ -2,5 +2,5 @@ driver = mysql
 connect = host={{ DBHOST }} dbname={{ DBNAME }} user={{ DBUSER }} password={{ DBPASS }}
 default_pass_scheme = SHA512-CRYPT
 iterate_query = SELECT username AS user FROM mailbox
-user_query = SELECT CONCAT('/var/mail/vhosts/',maildir) AS home, {{ VMAILUID }} AS uid, {{ VMAILGID }} AS gid, CONCAT('*:bytes=',quota) AS quota_rule FROM mailbox WHERE username = '%u' AND active = 1
+user_query = SELECT CONCAT('/var/mail/vhosts/',maildir) AS home, CONCAT('maildir:/var/mail/vhosts/',maildir,'{{ VMAIL_SUBDIR }}') AS mail, {{ VMAILUID }} AS uid, {{ VMAILGID }} AS gid, CONCAT('*:bytes=',quota) AS quota_rule FROM mailbox WHERE username = '%u' AND active = 1
 password_query = SELECT password, CONCAT('*:bytes=',quota) AS userdb_quota_rule FROM mailbox WHERE username = '%u' AND active = 1

--- a/rootfs/usr/local/bin/startup
+++ b/rootfs/usr/local/bin/startup
@@ -5,6 +5,7 @@ export FQDN
 export DOMAIN
 export VMAILUID
 export VMAILGID
+export VMAIL_SUBDIR
 export DBHOST
 export DBNAME
 export DBUSER
@@ -26,6 +27,7 @@ FQDN=$(hostname --fqdn)
 DOMAIN=$(hostname --domain)
 VMAILUID=${VMAILUID:-1024}
 VMAILGID=${VMAILGID:-1024}
+VMAIL_SUBDIR=${VMAIL_SUBDIR:-"mail"}
 DBHOST=${DBHOST:-mariadb}
 DBNAME=${DBNAME:-postfix}
 DBUSER=${DBUSER:-postfix}
@@ -165,6 +167,7 @@ _envtpl() {
   envtpl "$1.tpl"
 }
 
+_envtpl /etc/cron.d/spamassassin
 _envtpl /etc/postfix/main.cf
 _envtpl /etc/postfix/virtual
 _envtpl /etc/postfix/header_checks


### PR DESCRIPTION
For historic reason, my virtual mailboxes are not in the `mail/` subdirectory of the virtual user's home, and I didn't want to change that when migrating to this container.

This PR allows to configure the mailbox subdirectory.