### PR TITLE
Fix copy-and-paste error in tests

### DIFF
--- a/test/tests.bats
+++ b/test/tests.bats
@@ -126,7 +126,7 @@
 }
 
 @test "checking process: gross (disabled in reverse configuration)" {
-  run docker exec mailserver_default /bin/bash -c "ps aux --forest | grep '[/]usr/sbin/grossd -f /etc/gross/grossd.conf -d'"
+  run docker exec mailserver_reverse /bin/bash -c "ps aux --forest | grep '[/]usr/sbin/grossd -f /etc/gross/grossd.conf -d'"
   [ "$status" -eq 1 ]
 }
 


### PR DESCRIPTION
Test gross on both `mailserver_default` and `mailserver_reverse` instead of twice on `mailserver_default`.Test gross on both `mailserver_default` and `mailserver_reverse` instead of twice on `mailserver_default`.

Ref https://github.com/hardware/mailserver/commit/068ed14257fa5cd75cb5bcd7887a0f29d710afc3#diff-ede4b54c3503a7d2e99a3d2fb577ac77R129