### PR TITLE
postfix: allow users to send mails from their alias addresses

### DIFF
--- a/rootfs/etc/postfix/sql/sender-login-maps.cf
+++ b/rootfs/etc/postfix/sql/sender-login-maps.cf
@@ -3,4 +3,4 @@ user     = {{ DBUSER }}
 password = {{ DBPASS }}
 dbname   = {{ DBNAME }}
 
-query = SELECT username FROM mailbox WHERE username='%s' AND active = 1
+query = SELECT username FROM mailbox WHERE username='%s' AND active = 1 UNION SELECT goto FROM alias WHERE address="%s" AND active = 1


### PR DESCRIPTION
changed the sender-login-maps to return alias destinations, so users are allowed to send mails from their alias addresses