### PR TITLE
Added link to mariadb

### DIFF
--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -48,6 +48,8 @@ services:
     depends_on:
       - mailserver
       - mariadb
+    links:
+      - mariadb:mariadb
 
   # Webmail (Optional)
   # https://github.com/hardware/rainloop
@@ -62,6 +64,8 @@ services:
     depends_on:
       - mailserver
       - mariadb
+    links:
+      - mariadb:mariadb
 
   # Authoritative DNS server (Optional)
   # https://github.com/hardware/nsd-dnssec

--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -30,6 +30,8 @@ services:
     # - /mnt/docker/nginx/certs:/etc/letsencrypt
     depends_on:
       - mariadb
+    links:
+      - mariadb:mariadb
 
   # Administration interface
   # https://github.com/hardware/postfixadmin


### PR DESCRIPTION
Added link to mariadb for correct /etc/hosts to be written within the hardware/mailserver container. The mailserver container would error otherwise.