### PR TITLE
Move amavis data and postfix queues to /var/mail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN BUILD_DEPS=" \
     pbzip2 \
     dnsutils \
     ca-certificates \
+ && rm -rf /var/spool/postfix && ln -s /var/mail/postfix/spool /var/spool/postfix \
  && pip install envtpl \
  && cd /tmp \
  && wget -q https://github.com/krallin/tini/releases/download/v$TINI_VER/tini_$TINI_VER.deb \

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,8 @@ RUN BUILD_DEPS=" \
  && ln -s /var/mail/postfix/spool     /var/spool/postfix \
  && ln -s /var/mail/amavis/bayes      /var/lib/amavis/.spamassassin \
  && ln -s /var/mail/amavis/quarantine /var/lib/amavis/virusmails \
+ && mv /var/lib/clamav /var/mail/clamav \
+ && ln -s /var/mail/clamav /var/lib/clamav \
  && pip install envtpl \
  && cd /tmp \
  && wget -q https://github.com/krallin/tini/releases/download/v$TINI_VER/tini_$TINI_VER.deb \

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,11 @@ RUN BUILD_DEPS=" \
     pbzip2 \
     dnsutils \
     ca-certificates \
- && rm -rf /var/spool/postfix && ln -s /var/mail/postfix/spool /var/spool/postfix \
+ && rm -rf /var/spool/postfix \
+ && rm -rf /var/lib/amavis/.spamassassin /var/lib/amavis/virusmails \
+ && ln -s /var/mail/postfix/spool     /var/spool/postfix \
+ && ln -s /var/mail/amavis/bayes      /var/lib/amavis/.spamassassin \
+ && ln -s /var/mail/amavis/quarantine /var/lib/amavis/virusmails \
  && pip install envtpl \
  && cd /tmp \
  && wget -q https://github.com/krallin/tini/releases/download/v$TINI_VER/tini_$TINI_VER.deb \

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ init:
 		-e TESTING=true \
 		-v "`pwd`/test/share/tests":/tmp/tests \
 		-v "`pwd`/test/share/ssl":/var/mail/ssl \
-		-v "`pwd`/test/share/postfix":/var/mail/postfix \
+		-v "`pwd`/test/share/postfix/custom.conf":/var/mail/postfix/custom.conf \
 		-h mail.domain.tld \
 		-t $(NAME)
 

--- a/rootfs/etc/amavis/conf.d/50-user
+++ b/rootfs/etc/amavis/conf.d/50-user
@@ -8,10 +8,6 @@ use strict;
 # the directives you can use in this file
 #
 
-### Move data directories to /var/mail so they're stored in the volume
-$helpers_home = "/var/mail/amavis";
-$QUARANTINEDIR = "$helpers_home/quarantine";
-
 ### Maximun number of child processes
 $max_servers = AMAVIS_MAX_SERVERS;
 

--- a/rootfs/etc/amavis/conf.d/50-user
+++ b/rootfs/etc/amavis/conf.d/50-user
@@ -8,6 +8,10 @@ use strict;
 # the directives you can use in this file
 #
 
+### Move data directories to /var/mail so they're stored in the volume
+$helpers_home = "/var/mail/amavis";
+$QUARANTINEDIR = "$helpers_home/quarantine";
+
 ### Maximun number of child processes
 $max_servers = AMAVIS_MAX_SERVERS;
 

--- a/rootfs/etc/supervisor/supervisord.conf
+++ b/rootfs/etc/supervisor/supervisord.conf
@@ -33,6 +33,7 @@ autorestart=true
 [program:dovecot]
 command=/usr/sbin/dovecot -c /etc/dovecot/dovecot.conf -F
 autorestart=true
+autostart=false
 
 [program:clamav_init]
 command=/usr/local/bin/clamav

--- a/rootfs/usr/local/bin/amavisd
+++ b/rootfs/usr/local/bin/amavisd
@@ -11,10 +11,13 @@ fi
 # Fix permissions
 usermod -aG amavis clamav
 
-# Create data directory
-mkdir -p /var/mail/amavis
-chown amavis:amavis /var/mail/amavis
-chmod 750 /var/mail/amavis
+# Create data directories
+for sub in "" quarantine bayes; do
+    mkdir -p /var/mail/amavis/$sub
+    chown amavis:amavis /var/mail/amavis/$sub
+    chmod 750 /var/mail/amavis/$sub
+done
+chmod 700 /var/mail/amavis/bayes
 
 # Start amavisd and amavisd-milter
 supervisorctl start amavisd && sleep 5

--- a/rootfs/usr/local/bin/amavisd
+++ b/rootfs/usr/local/bin/amavisd
@@ -11,6 +11,11 @@ fi
 # Fix permissions
 usermod -aG amavis clamav
 
+# Create data directory
+mkdir -p /var/mail/amavis
+chown amavis:amavis /var/mail/amavis
+chmod 750 /var/mail/amavis
+
 # Start amavisd and amavisd-milter
 supervisorctl start amavisd && sleep 5
 supervisorctl start amavisd-milter

--- a/rootfs/usr/local/bin/clamav
+++ b/rootfs/usr/local/bin/clamav
@@ -6,7 +6,7 @@ fi
 
 # Create directories and set permissions
 mkdir -p /var/run/clamav && chown clamav:clamav /var/run/clamav
-mkdir -p /var/lib/clamav && chown -R clamav:clamav /var/lib/clamav
+mkdir -p /var/mail/clamav && chown -R clamav:clamav /var/mail/clamav
 
 # Update virus databases
 /usr/bin/freshclam --quiet --config-file=/etc/clamav/freshclam.conf

--- a/rootfs/usr/local/bin/postfix
+++ b/rootfs/usr/local/bin/postfix
@@ -24,7 +24,8 @@ chmod 0644 /etc/postfix/header_checks
 chmod 0644 /etc/postfix/main.cf
 chmod 0644 /etc/postfix/master.cf
 
-# Start Postfix
+# Start Postfix and Dovecot
 /usr/sbin/postfix -c /etc/postfix start
+supervisorctl start dovecot
 
 sleep infinity

--- a/rootfs/usr/local/bin/postfix
+++ b/rootfs/usr/local/bin/postfix
@@ -4,11 +4,16 @@
 # and saving state
 trap "{ /usr/sbin/postfix stop; exit 0; }" EXIT
 
+for subdir in "" etc dev usr usr/lib usr/lib/sasl2 usr/lib/zoneinfo; do
+    mkdir -p  /var/mail/postfix/spool/$subdir
+    chmod 755 /var/mail/postfix/spool/$subdir
+done
+
 # Add etc files to Postfix chroot jail
-cp -f /etc/services /var/spool/postfix/etc/services
-cp -f /etc/hosts /var/spool/postfix/etc/hosts
-cp -f /etc/localtime /var/spool/postfix/etc/localtime
-cp -f /etc/resolv.conf /var/spool/postfix/etc/resolv.conf
+cp -f /etc/services    /var/mail/postfix/spool/etc/services
+cp -f /etc/hosts       /var/mail/postfix/spool/etc/hosts
+cp -f /etc/localtime   /var/mail/postfix/spool/etc/localtime
+cp -f /etc/resolv.conf /var/mail/postfix/spool/etc/resolv.conf
 
 # Build header_checks and virtual index files
 /usr/sbin/postmap /etc/postfix/header_checks

--- a/rootfs/usr/local/bin/startup
+++ b/rootfs/usr/local/bin/startup
@@ -320,7 +320,11 @@ useradd -g vmail -u "$VMAILUID" vmail -d /var/mail
 mkdir /var/run/dovecot
 mkdir /var/run/fetchmail
 
-chown -R vmail:vmail /var/mail
+find /var/mail \( \
+    -name postfix -prune -o \
+    -name amavis -prune \
+\) -o -print0 | xargs -0 chown vmail:vmail
+
 chown -R vmail:dovecot /etc/dovecot
 chmod -R o-rwx /etc/dovecot
 chown -R dovecot:dovecot /var/run/dovecot

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -465,7 +465,7 @@
   run docker exec mailserver_default /bin/sh -c "grep -i 'Passed SPAM' /var/log/mail.log | grep spam@example.com | wc -l"
   [ "$status" -eq 0 ]
   [ "$output" = 1 ]
-  run docker exec mailserver_default /bin/sh -c "find /var/lib/amavis/virusmails -type f | wc -l"
+  run docker exec mailserver_default /bin/sh -c "find /var/lib/amavis/virusmails/ -type f | wc -l"
   [ "$status" -eq 0 ]
   [ "$output" = 1 ]
 }


### PR DESCRIPTION
As discussed in #135.  I ended up using a symlink for /var/spool/postfix because there were too many other packages with configuration coded there, so changing only postfix's setting for it broke a whole bunch of other packages.  I've confirmed at this point that the `.spamassasin` directory is moved, and postfix+dovecot appear to work normally.

I have *not* confirmed that the quarantine directory is actually moved, however.  I'm not sure how to test that; it's possible that the directory needs to be explicitly created in the volume for it to work.