### PR TITLE
Bugfix infinite appened DatabaseMirror

### DIFF
--- a/rootfs/etc/s6.d/freshclam/run
+++ b/rootfs/etc/s6.d/freshclam/run
@@ -4,7 +4,8 @@ if [ "$DISABLE_CLAMAV" = true ]; then
   exit 0
 fi
 
-echo "DatabaseMirror db.fr.clamav.net" >> /etc/clamav/freshclam.conf
+grep -q -F 'db.fr.clamav.net' /etc/clamav/freshclam.conf || \
+      echo 'DatabaseMirror db.fr.clamav.net' >> /etc/clamav/freshclam.conf
 
 sed -i -e 's/^Foreground .*$/Foreground true/g' \
        -e 's/^LogSyslog .*$/LogSyslog true/g' \


### PR DESCRIPTION
Bugfix infinite appened `DatabaseMirror db.fr.clamav.net` to `/etc/clamav/freshclam.conf` when the errors start `/rootfs/etc/s6.d/freshclam/run`

* https://github.com/hardware/mailserver/blob/fb53890/rootfs/etc/s6.d/freshclam/run#L7

#### /rootfs/etc/s6.d/freshclam/run
```
ERROR: Can't change dir to /var/lib/clamav
mail freshclam[...]: Can't change dir to /var/lib/clamav
mail root: s6-supervise : spawning freshclam process
ERROR: Can't change dir to /var/lib/clamav
mail freshclam[...]: Can't change dir to /var/lib/clamav
mail root: s6-supervise : spawning freshclam process
....
```

#### Quick fix
- disable clamav `DISABLE_CLAMAV=true`