### PR TITLE
Rspamd port must be exposed to be reachable by proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y -q --no-install-recommends \
  && rm -rf /tmp/* /var/lib/apt/lists/* /var/cache/debconf/*-old
 
 VOLUME /var/mail /etc/letsencrypt
-EXPOSE 25 143 465 587 993 4190
+EXPOSE 25 143 465 587 993 4190 11334
 COPY rootfs /
 RUN chmod +x /usr/local/bin /services/*/run /services/.s6-svscan/finish
 CMD ["run.sh"]


### PR DESCRIPTION
To be reachable by other containers, the port 11334 should be exposed.