### PR TITLE
Removed VOLUME instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ RUN apt-get update && apt-get install -y -q --no-install-recommends \
  && apt-get clean \
  && rm -rf /tmp/* /var/lib/apt/lists/* /var/cache/debconf/*-old
 
-VOLUME /var/mail /etc/letsencrypt
 EXPOSE 25 143 465 587 993 4190 11334
 COPY rootfs /
 RUN chmod +x /usr/local/bin /services/*/run /services/.s6-svscan/finish


### PR DESCRIPTION
`VOLUME` instruction should not be used anymore because it creates a new volume on each container creation. If you remove the container the volume will be orphan and the data inaccessible (by containers). As a result, we have a lot of disk space used with old data.

The docker recommendation is to use `host volumes` or `named volumes` (recommended).