### PR TITLE
Save pidfiles for logrotate to pkill HUP

### DIFF
--- a/rootfs/services/clamd/run
+++ b/rootfs/services/clamd/run
@@ -1,3 +1,5 @@
 #!/bin/bash
 logger -p mail.info "s6-supervise : virus database downloaded, spawning clamd process"
+
+echo $$>/var/run/clamav/clamd.pid
 exec clamd &>/dev/null

--- a/rootfs/services/freshclam/run
+++ b/rootfs/services/freshclam/run
@@ -10,4 +10,5 @@ fi
 # Start clamd run script
 s6-svc -u /services/clamd
 
+echo $$>/var/run/clamav/freshclam.pid
 exec freshclam -d &>/dev/null


### PR DESCRIPTION
I get a weekly email from my container complaining about

```
/etc/cron.daily/logrotate:
pkill: pidfile not valid
```

It turns out the issue is that logrotate is trying to HUP the clamav processes, but there are no pidfiles for them.  This patch changes the run scripts to create pidfiles where the /etc/init.d scripts used by logrotate expect them to be.  I'm not sure if it'll get rid of the error message if clamav is disabled, but it's a start.  :)