### PR TITLE
Custom configuration for dovecot

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,7 @@ Documentation : https://www.unbound.net/documentation/unbound-control.html
    ├──dovecot
    |     instances
    |     ssl-parameters.dat
+   |  ├──conf.d (Custom dovecot configuration)
    ├──clamav (ClamAV databases directory)
    │     bytecode.cvd
    │     daily.cld
@@ -543,6 +544,18 @@ docker logs -f mailserver
 [INFO] Override : delay_warning_time = 2h
 [INFO] Custom Postfix configuration file loaded
 ```
+
+### Custom configuration for dovecot
+
+Dovecot is configured to "just work". Sometimes you might want to add additional configuration parameters or override the default ones. 
+You can do so by placing configuration files to the persistent folder /mnt/docker/mail/dovecot/conf.d.
+
+Example:
+
+```bash
+# echo 'login_greeting = Dovecot welcomes you!' > /mnt/docker/mail/dovecot/10-custom.conf
+```
+
 
 ### Email client settings :
 

--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -35,6 +35,7 @@ services:
     volumes:
       - /mnt/docker/mail:/var/mail
     # - /mnt/docker/nginx/certs:/etc/letsencrypt
+      - /mnt/docker/mail/dovecot/conf.d:/etc/dovecot/custom.conf.d
     depends_on:
       - mariadb
       - redis

--- a/rootfs/etc/dovecot/dovecot.conf
+++ b/rootfs/etc/dovecot/dovecot.conf
@@ -2,3 +2,4 @@
 protocols = imap lmtp
 listen = *
 !include conf.d/*.conf
+!include custom.conf.d/*.conf

--- a/rootfs/etc/dovecot/dovecot.conf
+++ b/rootfs/etc/dovecot/dovecot.conf
@@ -2,4 +2,4 @@
 protocols = imap lmtp
 listen = *
 !include conf.d/*.conf
-!include custom.conf.d/*.conf
+!include_try custom.conf.d/*.conf


### PR DESCRIPTION
Currently it seems impossible to create a custom configuration for dovecot.
This is an easy addition to include a persistent folder to the dovecot.conf to override or add custom configuration files.