### PR TITLE
Override postfix configuration file

### DIFF
--- a/rootfs/usr/local/bin/run.sh
+++ b/rootfs/usr/local/bin/run.sh
@@ -263,10 +263,12 @@ _envtpl /usr/local/bin/fetchmail.pl
 
 # Override Postfix configuration
 if [ -f /var/mail/postfix/custom.conf ]; then
+  # Ignore blank lines and comments
+  sed -e '/^\s*$/d' -e '/^#/d' /var/mail/postfix/custom.conf | \
   while read line; do
     echo "[INFO] Override : ${line}"
     postconf -e "$line"
-  done < /var/mail/postfix/custom.conf
+  done
   echo "[INFO] Custom Postfix configuration file loaded"
 fi
 


### PR DESCRIPTION
## Description

When overriding postfix configuration file, ignore blank lines and comments.

Fixes # (issue)

* What is the current behavior (you can also link to an open issue here) ?
postconf is being executed for every line.

* What is the new behavior (if this is a feature change) ?
postconf will be executed only on relevant lines.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Status

- [X] Ready

## How has this been tested ?

Create a file `/mnt/docker/mail/postfix/custom.conf`

- [X] Override postfix config
```
# The address type ("ipv6", "ipv4" or "any") that the Postfix SMTP client will try first, when a destination has IPv6 and IPv4 addresses with equal MX preference.
smtp_address_preference = ipv4

# The maximal size in bytes of a message, including envelope information.
message_size_limit = 52428800
```
Should output on docker `mailserver` log:
```
[INFO] Override : smtp_address_preference = ipv4
[INFO] Override : message_size_limit = 52428800
```