### PR TITLE
Add IPv6 NAT support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Simple and full-featured mail server as a set of multiple docker images includes
 - [Third-party clamav signature databases](#third-party-clamav-signature-databases)
 - [DNS resolver](#unbound-dns-resolver)
 - [PostgreSQL support](#postgresql-support)
+- [IPv6 support](#ipv6-support)
 - [Persistent files and folders](#persistent-files-and-folders-in-mntdockermail-docker-volume)
 - [Override postfix configuration](#override-postfix-configuration)
 - [Override dovecot configuration](#custom-configuration-for-dovecot)
@@ -155,8 +156,9 @@ You can audit your mailserver with the following assessment services :
 :bulb: The reverse proxy used in this setup is [Traefik](https://traefik.io/), but you can use the solution of your choice (Nginx, Apache, Haproxy, Caddy, H2O...etc).
 
 ```bash
-# Create a new docker network for Traefik
+# Create a new docker network for Traefik (IPv4 only)
 docker network create http_network
+# If you want to support IPv6, please refer to [IPv6 support]
 
 # Create the required folders and files
 mkdir -p /mnt/docker/traefik/acme && cd /mnt/docker \
@@ -630,6 +632,55 @@ postgres:
   networks:
     - mail_network
 ```
+
+### IPv6 support
+
+If you want to support inbound IPv6 connections, you need to create a docker network with IPv6 enabled, otherwise, you may have some issues with docker internal networking.
+
+The procedure is quite simple:
+
+- Remove your old `http_network` (if you already have created it)
+
+```bash
+docker network rm http_network
+```
+
+- Choose a private ipv6 address range (/64)
+  - You can easily get a unique private IPv6 address range on [SimpleDNS website](https://simpledns.com/private-ipv6)
+
+- Create a docker network with IPv6 enabled
+
+```bash
+# Replace subnet mask with your own "Combined/CID"
+docker network create http_network --ipv6 --subnet "fd00:0000:0000:0000::/64"
+```
+
+- Append this to your `docker-compose.yml`
+
+```yml
+# IPv6NAT
+# https://github.com/robbertkl/docker-ipv6nat
+# https://hub.docker.com/r/robbertkl/ipv6nat/
+ipv6nat:
+  image: robbertkl/ipv6nat
+  container_name: ipv6nat
+  restart: ${RESTART_MODE}
+  volumes:
+    - /var/run/docker.sock:/var/run/docker.sock:ro
+    - /lib/modules:/lib/modules:ro
+  depends_on:
+    - mailserver
+  cap_add:
+    - NET_ADMIN
+    - SYS_MODULE
+  network_mode: "host"
+```
+
+- Create a record named `mail` of type `AAAA` with your **public** IPv6 address in your DNS provider.
+
+Done! This is all the configuration needed to enable inbound IPv6 support on this mailserver.
+
+You can read more on how and why [robbertkl/docker-ipv6nat](https://github.com/robbertkl/docker-ipv6nat) container mimics NAT for IPv6 on his page.
 
 ### Persistent files and folders in /mnt/docker/mail Docker volume
 

--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -1,5 +1,12 @@
 version: "3"
 
+# IPv4 only
+# docker network create http_network
+
+# IPv4/IPv6 network
+# docker network create http_network --ipv6 --subnet "fd00:0000:0000:0000::/64"
+# Refer to https://github.com/hardware/mailserver/#ipv6-support for more information.
+
 networks:
   http_network:
     external: true


### PR DESCRIPTION
## Description

Add IPv6 NAT support.
Helps to solve IPv6 network problems like identifying the real ip address of connections through IPv6.

Fixes # (issue)
https://github.com/hardware/mailserver/issues/221

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Status

- [X] Ready

## Todo List
- [X] Documentation

## How has this been tested ?

I'm currently running this for 20 days, no issues so far.

- IPv4 connection:

**Example**
`telnet your_server_ipv4 587`
`telnet 104.131.xxx.xxx 25`

**Expected**

```plain
mailserver      | 2018-04-08T02:50:12.073149+00:00 mail postfix/submission/smtpd[625]: connect from unknown[186.214.xxx.xxx]
mailserver      | 2018-04-08T02:50:12.357745+00:00 mail postfix/submission/smtpd[625]: lost connection after CONNECT from unknown[186.214.xxx.xxx]
mailserver      | 2018-04-08T02:50:12.357854+00:00 mail postfix/submission/smtpd[625]: disconnect from unknown[186.214.xxx.xxx] commands=0/0
```

- IPv6 connection:

**Example**
`telnet your_server_ipv6 587`
`telnet 2604:a880:800:10::xxx:xxxx 587`

**Expected**

```plain
mailserver      | 2018-04-08T02:50:15.558027+00:00 mail postfix/submission/smtpd[625]: connect from unknown[2804:7f1:4080:d3a2:xxxx:xxxx:xxxx:xxxx]
mailserver      | 2018-04-08T02:50:16.813053+00:00 mail postfix/submission/smtpd[625]: lost connection after CONNECT from unknown[2804:7f1:4080:d3a2:xxxx:xxxx:xxxx:xxxx]
mailserver      | 2018-04-08T02:50:16.813152+00:00 mail postfix/submission/smtpd[625]: disconnect from unknown[2804:7f1:4080:d3a2:xxxx:xxxx:xxxx:xxxx] commands=0/0
```

You can check your logs with:

`docker-compose logs -f mailserver`
or
`docker logs -f mailserver`

If it is working properly you will see the REAL ip address from your client on the IPv6 test.

Like this:
> mailserver      | 2018-04-08T02:50:15.558027+00:00 mail postfix/submission/smtpd[625]: connect from **unknown[2804:7f1:4080:d3a2:xxxx:xxxx:xxxx:xxxx]**

If IPv6nat is not enable, you will see something like this:
> mailserver      | 2018-04-08T02:50:12.073149+00:00 mail postfix/submission/smtpd[625]: connect from **unknown[172.18.xxx.xxx]**


