### PR TITLE
PostgreSQL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ init:
 		-e POSTGRES_USER=postfix \
 		-e POSTGRES_PASSWORD=testpasswd \
 		-v "`pwd`/test/config/postgres":/docker-entrypoint-initdb.d \
-		-t postgres:10.3-alpine
+		-t postgres:10.4-alpine
 
 	docker run \
 		-d \

--- a/README.md
+++ b/README.md
@@ -619,7 +619,7 @@ rainloop:
 # https://github.com/docker-library/postgres
 # https://postgresql.org/
 postgres:
-  image: postgres:10.3-alpine
+  image: postgres:10.4-alpine
   container_name: postgres
   restart: ${RESTART_MODE}
   # Info : These variables are ignored when the volume already exists (if databases was created before).

--- a/README.md
+++ b/README.md
@@ -622,6 +622,7 @@ postgres:
   image: postgres:10.4-alpine
   container_name: postgres
   restart: ${RESTART_MODE}
+  stop_signal: SIGINT                 # Fast Shutdown mode
   # Info : These variables are ignored when the volume already exists (if databases was created before).
   environment:
     - POSTGRES_DB=postfix


### PR DESCRIPTION
## Description

**Update database to PostgreSQL 10.4.**

As stated in [release page](https://www.postgresql.org/docs/10/static/release-10-4.html#id-1.11.6.5.4):

> A dump/restore is not required for those running 10.X.

Nothing special about it...

**Improved database shutdown.**

> Compose stop attempts to stop a container by sending a SIGTERM. It then waits for a default timeout of 10 seconds. After the timeout, a SIGKILL is sent to the container to forcefully kill it. 

https://docs.docker.com/compose/faq/#can-i-control-service-startup-order

> SIGTERM = Smart Shutdown
> It is best not to use SIGKILL to shut down the server 

https://www.postgresql.org/docs/10/static/server-shutdown.html

Since PostgreSQL 9.5 uses `fast` as the default shutdown mode.
https://paquier.xyz/postgresql-2/postgres-9-5-feature-highlight-pgctl-default-mode/
(I could not figure out why the docker image doesn't.)

This is why I changed to use` Fast Shutdown` (`SIGINT`), allowing the database to close idle connections and stop the container in clean way.

Fixes # (issue)

* What is the current behavior (you can also link to an open issue here) ?
```
LOG:  received smart shutdown request
...
LOG:  database system was interrupted; last known up at 2018-05-15 04:31:58 UTC
LOG:  database system was not properly shut down; automatic recovery in progress,
LOG:  redo starts at 0/F7E7F58,
LOG:  invalid record length at 0/F7E8050: wanted 24, got 0,
LOG:  redo done at 0/F7E8018,
LOG:  database system is ready to accept connections
```

* What is the new behavior (if this is a feature change) ?
```
LOG:  received fast shutdown request
LOG:  aborting any active transactions
...
LOG:  database system was shut down at 2018-05-15 04:43:36 UTC
LOG:  database system is ready to accept connections
```

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Refactoring (a change that neither fixes a bug nor adds a feature)

## Status

- [X] Ready

## How has this been tested ?

Using in production for more than a week.