### PR TITLE
More ClamAV improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,8 +153,10 @@ init:
 
 fixtures:
 
-	# Wait for clamav virus database update
-	sleep 120
+	# Wait for clamav unofficial sigs database update
+	docker exec mailserver_default /bin/sh -c "while [ -f /var/lib/clamav-unofficial-sigs/pid/clamav-unofficial-sigs.pid ] ; do sleep 1 ; done"
+	# Wait for clamav load databases
+	docker exec mailserver_default /bin/sh -c "while ! echo PING | nc -z 0.0.0.0 3310 ; do sleep 1 ; done"
 
 	docker exec mailserver_default /bin/sh -c "nc 0.0.0.0 25 < /tmp/tests/email-templates/external-to-existing-user.txt"
 	docker exec mailserver_default /bin/sh -c "nc 0.0.0.0 25 < /tmp/tests/email-templates/external-to-existing-user-spam-learning.txt"

--- a/rootfs/services/_parent/run
+++ b/rootfs/services/_parent/run
@@ -19,12 +19,13 @@ s6-svc -u /services/rspamd
 s6-svc -u /services/cron
 
 if [ "$DISABLE_CLAMAV" = false ]; then
-  s6-svc -u /services/freshclam && s6-svwait -u /services/clamd
+  s6-svc -u /services/freshclam
   if [ -f "/var/mail/clamav-unofficial-sigs/user.conf" ]; then
     logger -p mail.info "s6-supervise : clamav unofficial signature update running"
     clamav-unofficial-sigs.sh &>/dev/null
     logger -p mail.info "s6-supervise : clamav unofficial signature update done"
   fi
+  s6-svwait -u /services/clamd
 fi
 
 sleep 2

--- a/rootfs/usr/local/bin/run.sh
+++ b/rootfs/usr/local/bin/run.sh
@@ -665,8 +665,8 @@ sed -i '/^DatabaseMirror/ d' /etc/clamav/freshclam.conf
 
 # Add some database mirrors
 cat <<EOT >> /etc/clamav/freshclam.conf
+DatabaseMirror db.local.clamav.net
 DatabaseMirror switch.clamav.net
-DatabaseMirror clamav.iol.cz
 DatabaseMirror clamav.easynet.fr
 DatabaseMirror clamav.begi.net
 DatabaseMirror clamav.univ-nantes.fr

--- a/test/share/tests/clamav/test1.eml
+++ b/test/share/tests/clamav/test1.eml
@@ -1,0 +1,46 @@
+Return-Path: <sarah.connor@domain.tld>
+Delivered-To: john.doe@domain.tld
+Received: from mail.domain.tld
+	by mail.domain.tld (Dovecot) with LMTP id edNuCu2rTltXKAAAIyBrWA
+	for <john.doe@domain.tld>; Wed, 18 Jul 2018 02:54:37 +0000
+Received: from mail.domain.tld (mail.domain.tld [IPv6:::1])
+	(using TLSv1.2 with cipher ECDHE-RSA-AES256-GCM-SHA384 (256/256 bits))
+	(No client certificate requested)
+	by mail.domain.tld (Postfix) with ESMTPS id 59C511680F
+	for <john.doe@domain.tld>; Wed, 18 Jul 2018 02:54:36 +0000 (UTC)
+Received: by mail.domain.tld with SMTP id p6-v6so2725008ljc.5
+        for <john.doe@domain.tld>; Tue, 17 Jul 2018 19:54:36 -0700 (PDT)
+MIME-Version: 1.0
+From: Sarah Connor <sarah.connor@domain.tld>
+Date: Tue, 17 Jul 2018 23:54:22 -0300
+Message-ID: <CADmvPVrrnCTuY-ZgJPgoS+QzTkoe=nncNpVoTEf-2=zp3Jt=eg@mail.gmail.com>
+Subject: test1
+To: john.doe@domain.tld
+Content-Type: multipart/mixed; boundary="000000000000c01a6a05713d2ecf"
+
+--000000000000c01a6a05713d2ecf
+Content-Type: multipart/alternative; boundary="000000000000c01a6805713d2ecd"
+
+--000000000000c01a6805713d2ecd
+Content-Type: text/plain; charset="UTF-8"
+
+test1
+
+--000000000000c01a6805713d2ecd
+Content-Type: text/html; charset="UTF-8"
+
+<div dir="ltr">test1</div>
+
+--000000000000c01a6805713d2ecd--
+--000000000000c01a6a05713d2ecf
+Content-Type: text/plain; charset="US-ASCII"; name="test1.txt"
+Content-Disposition: attachment; filename="test1.txt"
+Content-Transfer-Encoding: base64
+Content-ID: <f_jjqj9iai0>
+X-Attachment-Id: f_jjqj9iai0
+
+PCFET0NUWVBFIGh0bWw+DQo8aHRtbD4NCjxoZWFkPg0KPHRpdGxlPlNhbmVzZWN1cml0eTwvdGl0
+bGU+DQo8L2hlYWQ+DQoNCjxib2R5Pg0KPHA+Ym9keV9ycmc2M3VoajJ1Y3llY2NydXg3ZDgzYTRx
+ZDV1YTV2bmxnd2pwNmI2Zm1wenBvYnpqYWJmdGVodWhyYXhmYnl6enp6ejwvcD4NCjwvYm9keT4N
+Cg0KPC9odG1sPg0K
+--000000000000c01a6a05713d2ecf--

--- a/test/share/tests/clamav/test2.eml
+++ b/test/share/tests/clamav/test2.eml
@@ -1,0 +1,31 @@
+Return-Path: <sarah.connor@domain.tld>
+Delivered-To: john.doe@domain.tld
+Received: from mail.domain.tld
+	by mail.domain.tld (Dovecot) with LMTP id yaajLgSLTlvAIQAAIyBrWA
+	for <john.doe@domain.tld>; Wed, 18 Jul 2018 00:34:12 +0000
+Received: from mail.domain.tld (mail.domain.tld [IPv6:::1])
+	(using TLSv1.2 with cipher ECDHE-RSA-AES256-GCM-SHA384 (256/256 bits))
+	(No client certificate requested)
+	by mail.domain.tld (Postfix) with ESMTPS id 49323167C2
+	for <john.doe@domain.tld>; Wed, 18 Jul 2018 00:34:12 +0000 (UTC)
+Received: by mail.domain.tld with SMTP id f8-v6so2529119ljk.1
+        for <john.doe@domain.tld>; Tue, 17 Jul 2018 17:34:12 -0700 (PDT)
+MIME-Version: 1.0
+From: Sarah Connor <sarah.connor@domain.tld>
+Date: Tue, 17 Jul 2018 21:34:01 -0300
+Message-ID: <CADmvPVqAH-OB4Ei60UE3nZn3tSj+GWPr1979O8SgaMQzQpa2vA@mail.gmail.com>
+Subject: rrg63Uhj2UCyECcruX7D83A4qd5UA5vnlgwJp6b6fmPZpObZJAbftehuhRAXFby
+To: john.doe@domain.tld
+Content-Type: multipart/alternative; boundary="000000000000a57a8e05713b38d1"
+
+--000000000000a57a8e05713b38d1
+Content-Type: text/plain; charset="UTF-8"
+
+test2
+
+--000000000000a57a8e05713b38d1
+Content-Type: text/html; charset="UTF-8"
+
+<div dir="ltr">test2</div>
+
+--000000000000a57a8e05713b38d1--

--- a/test/share/tests/clamav/test3.eml
+++ b/test/share/tests/clamav/test3.eml
@@ -1,0 +1,21 @@
+Return-Path: <sarah.connor@domain.tld>
+Delivered-To: john.doe@domain.tld
+Received: from mail.domain.tld
+	by mail.domain.tld (Dovecot) with LMTP id qQ7+EyaLTlvAIQAAIyBrWA
+	for <john.doe@domain.tld>; Wed, 18 Jul 2018 00:34:46 +0000
+Received: from mail.domain.tld (mail.domain.tld [IPv6:::1)
+	(using TLSv1.2 with cipher ECDHE-RSA-AES256-GCM-SHA384 (256/256 bits))
+	(No client certificate requested)
+	by mail.domain.tld (Postfix) with ESMTPS id D9D7313E14
+	for <john.doe@domain.tld>; Wed, 18 Jul 2018 00:34:45 +0000 (UTC)
+Received: by mail.domain.tld with SMTP id u14-v6so2163659lfu.0
+        for <john.doe@domain.tld>; Tue, 17 Jul 2018 17:34:45 -0700 (PDT)
+MIME-Version: 1.0
+From: Sarah Connor <sarah.connor@domain.tld>
+Date: Tue, 17 Jul 2018 21:34:35 -0300
+Message-ID: <CADmvPVo3m=qBGKWsuTpR6=CLONtTaMC8jkMrBOpoVO8s0T6K6A@mail.gmail.com>
+Subject: test3
+To: john.doe@domain.tld
+Content-Type: text/plain; charset="UTF-8"
+
+body_rrg63Uhj2UCyECcruX7D83A4qd5UA5vnlgwJp6b6fmPZ0ajdjkwjnSSDfsdfsdfnwerd

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -1030,6 +1030,24 @@ load 'test_helper/bats-assert/load'
   assert_failure
 }
 
+@test "checking clamav-unofficial-sigs: TEST 1 — Html.Sanesecurity.TestSig_Type3_Bdy" {
+  run docker exec mailserver_default /bin/sh -c "clamscan --database=/var/lib/clamav/phish.ndb - < /tmp/tests/clamav/test1.eml"
+  assert_failure
+  assert_output --partial "Sanesecurity.TestSig_Type3_Bdy.4.UNOFFICIAL FOUND"
+}
+
+@test "checking clamav-unofficial-sigs: TEST 2 — Email.Sanesecurity.TestSig_Type4_Hdr" {
+  run docker exec mailserver_default /bin/sh -c "clamscan --database=/var/lib/clamav/phish.ndb - < /tmp/tests/clamav/test2.eml"
+  assert_failure
+  assert_output --partial "Sanesecurity.TestSig_Type4_Hdr.2.UNOFFICIAL FOUND"
+}
+
+@test "checking clamav-unofficial-sigs: TEST 3 — Email.Sanesecurity.TestSig_Type4_Bdy" {
+  run docker exec mailserver_default /bin/sh -c "clamscan --database=/var/lib/clamav/phish.ndb - < /tmp/tests/clamav/test3.eml"
+  assert_failure
+  assert_output --partial "Sanesecurity.TestSig_Type4_Bdy.3.UNOFFICIAL FOUND"
+}
+
 #
 # zeyple
 #


### PR DESCRIPTION
## Description

### Changes ClamAV database mirror list.

1.  The mirror `clamav.iol.cz` is dead so I removed it.
2. Re-added `db.local.clamav.net` because it redirects the user to the [closest pool of mirrors](https://www.clamav.net/documents/mirrors).
3. I didn't re-add the `database.clamav.net` because it is a round robin and the connection can be very bad. So I left the older entries on the mirror list as fallback.

Default values for `freshclam.conf` on *debian* are:
```
DatabaseMirror db.local.clamav.net
DatabaseMirror database.clamav.net
```

**Notes:**
Since I live in Brazil it's a 10x speed improvement for me downloading the files during tests.
On Digital Ocean or OVH it doesn't matter, the speed is good as before...

### Changes ClamAV initialization to update databases in parallel.
Since `clamav-unofficial-sigs` reload is working properly now, we can update both sources at same time.

**Scenarios on startup:**
- If `freshclam` finish first
It will launch `clamd`; then when `clamav-unofficial-sigs` completes it will reload `clamd` with additional signatures.

- If `clamav-unofficial-sigs` finish first
It will ignore the reload since `clamd` will be stopped; then when `freshclam` completes it will start `clamd` with both databases signatures at same time.

- There are no issues if both finish at almost same time. I did a few tests, `clamd` just "hangs" and queues the reloads.

### Reduces waiting time for update and load ClamAV signatures database during tests.

I replaced that `sleep 120` with a more "pragmatic way" of verifying that the updates have been completed.
Since that code is used by tests only, I think it is good/reliable enough.

(It saved almost 1 minute on travis-ci)

### Adds more tests to clamav-unofficial-sigs.

Just added three tests with some testing signatures, just to be sure that `clamav-unofficial-sigs` are downloaded and working properly.

## Type of change

- [X] Performance improvement
- [X] Refactoring (a change that neither fixes a bug nor adds a feature)
- [X] Test (adding missing tests or correcting existing ones)

## Status

- [X] Ready

## How has this been tested ?

Most of this changes are safe, so just lots of `make all-fast` and `make all`.

---

Let me know if there is any question.
Time to go to 🛌 
