### PR TITLE
Quote DBHOST in DNS lookup of database hostname

### DIFF
--- a/rootfs/usr/local/bin/run.sh
+++ b/rootfs/usr/local/bin/run.sh
@@ -299,7 +299,7 @@ grep -q "${DBHOST}" /etc/hosts
 
 if [ $? -ne 0 ]; then
   echo "[INFO] MariaDB/PostgreSQL hostname not found in /etc/hosts"
-  IP=$(dig A ${DBHOST} +short +search)
+  IP=$(dig A "${DBHOST}" +short +search)
   if [ -n "$IP" ]; then
     echo "[INFO] Container IP found, adding a new record in /etc/hosts"
     echo "${IP} ${DBHOST}" >> /etc/hosts


### PR DESCRIPTION
## Description

Quote `DBHOST` in DNS lookup of database hostname.

Fixes #271 

* Currently, if `DBHOST` is not explicitly specified and is not in `etc/hosts` the DNS lookup of the default name (mariadb) fails. This is a common scenerio in a kubernetes scenerio when a service with the name mariadb has been created.
* This pull requests makes a this DNS lookup succeed.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Status

- [X] Ready

## Todo List
- [X] Implementation
- [ ] Tests

## How has this been tested ?

Have built and tested on my personal registry and kubernetes cluster. Mailserver works as expected when this patch is applied.
