### PR TITLE
Fix invalid UTF-8 code point.

### DIFF
--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -60,7 +60,7 @@ services:
       - DBPASS=${DATABASE_USER_PASSWORD}       # MariaDB database password (required)
       - RSPAMD_PASSWORD=${RSPAMD_PASSWORD}     # Rspamd WebUI password (required)
     # - ADD_DOMAINS=aa.tld, www.bb.tld...      # Add additional domains separated by commas (needed for dkim keys etc.)
-    # - DEBUG_MODE=true                        # Enable Postfix, Dovecot and Rspamd verbose logging
+    # - DEBUG_MODE=true                        # Enable Postfix, Dovecot and Rspamd verbose logging
     # - ENABLE_POP3=true                       # Enable POP3 protocol
     # - ENABLE_FETCHMAIL=true                  # Enable fetchmail forwarding
     # - DISABLE_CLAMAV=true                    # Disable virus scanning


### PR DESCRIPTION
## Description

There is an invalid character on the line 63.
https://github.com/hardware/mailserver/blob/e7ba796dc22f277fd206730d0dfeb53598e1b95d/docker-compose.sample.yml#L63

Fixes # (issue)

* What is the current behavior
```
# docker-compose up -d
ERROR: .UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc2 in position 2657: invalid continuation byte
```

* What is the new behavior (if this is a feature change) ?
```docker-compose up``` working properly.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Status

- [X] Ready