### PR TITLE
Bump PostgreSQL version to 10.5.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ init:
 		-e POSTGRES_USER=postfix \
 		-e POSTGRES_PASSWORD=testpasswd \
 		-v "`pwd`/test/config/postgres":/docker-entrypoint-initdb.d \
-		-t postgres:10.4-alpine
+		-t postgres:10.5-alpine
 
 	docker run \
 		-d \

--- a/README.md
+++ b/README.md
@@ -671,7 +671,7 @@ rainloop:
 # https://github.com/docker-library/postgres
 # https://postgresql.org/
 postgres:
-  image: postgres:10.4-alpine
+  image: postgres:10.5-alpine
   container_name: postgres
   restart: ${RESTART_MODE}
   stop_signal: SIGINT                 # Fast Shutdown mode


### PR DESCRIPTION
## Description

**Update database to PostgreSQL 10.5.**

As stated in [release page](https://www.postgresql.org/docs/10/static/release-10-5.html#id-1.11.6.5.4):

> A dump/restore is not required for those running 10.X.

Nothing special about it...

## Type of change

- [X] Other...

## Status

- [X] Ready

## How has this been tested ?

Using in production for approximately two weeks.