### PR TITLE
Traefik 1.7

### DIFF
--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -15,7 +15,7 @@ networks:
 
 services:
   traefik:
-    image: traefik:1.6-alpine
+    image: traefik:1.7-alpine
     container_name: traefik
     restart: ${RESTART_MODE}
     ports:

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -32,8 +32,7 @@ storage = "/etc/traefik/acme/acme.json"
 entryPoint = "https"
 onHostRule = true
 onDemand = false
-  [acme.httpChallenge]
-  entryPoint = "http"
+  [acme.tlsChallenge]
 
 [docker]
 endpoint = "unix:///var/run/docker.sock"


### PR DESCRIPTION
* ACME now support TLS ALPN Challenge.
* H2C Support, not enabled.

https://blog.containo.us/traefik-1-7-yet-another-slice-of-awesomeness-2a9c99737889