### PR TITLE
Fix fetchmail, remove sslcertpath to use server certificates

### DIFF
--- a/rootfs/usr/local/bin/fetchmail.pl
+++ b/rootfs/usr/local/bin/fetchmail.pl
@@ -129,7 +129,7 @@ TXT
   print $file_handler $text;
   close $file_handler;
 
-  $ret=`/usr/bin/fetchmail -f $filename -i $run_dir/fetchmail.pid --sslcertfile {{ .CERTFILE }}`;
+  $ret=`/usr/bin/fetchmail -f $filename -i $run_dir/fetchmail.pid`;
 
   unlink $filename;
 


### PR DESCRIPTION
## Description

Fix fetchmail certification problem

Fixes # 342

## Type of change
Remove the sslcertfile option from the fetchmail call.
If removed the fetchmail will use the system CAs.

- [ X] Bug fix (non-breaking change which fixes an issue)

## Status

- [X ] Ready

## How has this been tested ?

Add a new fetchmail server via postfixadmin.
Before the fix, you will get an warning/error in logfile.
After fix, it checks the certificates right and no warning will be occur.

