### PR TITLE
Slightly lift sender restriction for mynetworks

### DIFF
--- a/rootfs/etc/postfix/main.cf
+++ b/rootfs/etc/postfix/main.cf
@@ -154,13 +154,17 @@ smtpd_relay_restrictions=
 
 # * reject_non_fqdn_sender : Reject when the MAIL FROM address is not in fully-qualified domain form
 # * reject_unknown_sender_domain : Reject when the MAIL FROM domain has no DNS MX, no DNS A record or a malformed MX record
-# * reject_sender_login_mismatch: Reject when the client is not (SASL) logged in as that MAIL FROM address owner or when the client is (SASL) logged in, but the client login name doesn't own the MAIL FROM address
+# * reject_authenticated_sender_login_mismatch : Reject when the client is (SASL) logged in, but the client login name doesn't own the MAIL FROM address
+# * permit_mynetworks : Permit the request when the client IP address matches any trusted network
+# * reject_unauthenticated_sender_login_mismatch : Reject when the client is not (SASL) logged in as that MAIL FROM address owner
 # * reject_rhsbl_sender : Reject when the MAIL FROM domain is blacklisted in dbl.spamhaus.org
 
 smtpd_sender_restrictions=
     reject_non_fqdn_sender,
     reject_unknown_sender_domain,
-    reject_sender_login_mismatch,
+    reject_authenticated_sender_login_mismatch,
+    permit_mynetworks,
+    reject_unauthenticated_sender_login_mismatch,
     reject_unlisted_sender,
     reject_rhsbl_sender dbl.spamhaus.org,
     check_sender_access hash:/etc/postfix/sender_access


### PR DESCRIPTION
## Description

This PR slightly lifts the sender restrictions for IPs in mynetworks in a reasonable way.

With the current `smtpd_sender_restrictions`, containers with IPs listed in the existing configuration variable `$RELAY_NETWORKS` are forced to use a fully _authenticated_ and _existing_ user to send out emails. This could cause issues with some services which expect local delivery to work without authentication. Also, the administrator might not want to create a dedicated mailbox user for the outgoing email address of a mail-sending service, but use an alias to process answers and bounces.

Therefore, this PR lifts the restrictions by adding `permit_mynetworks` to `smtpd_sender_restrictions`.

I groups a couple of `restrict_` directives before `permit_mynetworks` to force the administrator to work cleanly and use a properly crafted sender address for their internal services.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Status

- [x] Ready

## How has this been tested ?

Setup:

1) Spin up a container A (a mail-sending program)
2) Spin up mailserver with `$RELAY_NETWORKS=ip_of_A`
3) In postfixadmin, setup mailboxes src@example.com and dest@example.com

Test 1:

Make A send an emails from nobody@example.com (unauthorized) to dest@example.com and dest@outside-domain.com. Both should work.

Test 2:

Make A send an email from src@example.com to dest@example.com and dest@outside-domain.com. Both should work but only if sender is properly authenticated.
