### PR TITLE
Follow symlinks to copy /etc/letsencrypt/ certs set up by certbot.

### DIFF
--- a/rootfs/usr/local/bin/certs_helper.sh
+++ b/rootfs/usr/local/bin/certs_helper.sh
@@ -116,7 +116,7 @@ elif [ "$1" = "update_certs" ]; then
       echo "[INFO] Let's encrypt live directory found"
       echo "[INFO] Using $LETS_ENCRYPT_LIVE_PATH folder"
 
-      cp -RT "$LETS_ENCRYPT_LIVE_PATH/." "$NORMALIZED_CERT_PATH"
+      cp -RLT "$LETS_ENCRYPT_LIVE_PATH/." "$NORMALIZED_CERT_PATH"
 
     else
       echo "[INFO] No Let's encrypt live directory found"


### PR DESCRIPTION
## Description

The master branch (latest) uses the certs_helper.sh script to set up the SSL certs.

If the live letsencrypt/ directory uses symlinks (as is done by certbot), this setup fails.

The fix is simple. Follow symlinks in the cp command.

Fixes #391 

## Type of change

- [ X] Bug fix (non-breaking change which fixes an issue)

## Status

- [X ] Ready

## How has this been tested ?

Tested in a running container on two different domains.