### PR TITLE
Make tests work again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,9 @@ init:
 		-e MYSQL_DATABASE=postfix \
 		-e MYSQL_USER=postfix \
 		-e MYSQL_PASSWORD=testpasswd \
-		-v "`pwd`/test/config/mariadb":/docker-entrypoint-initdb.d \
-		-t mariadb:10.2
+		-v "`pwd`/test/config/mariadb/struct.sql":/docker-entrypoint-initdb.d/struct.sql \
+		-v "`pwd`/test/config/mariadb/bind.cnf":/etc/mysql/conf.d/bind.cnf \
+		-t mysql:5.7
 
 	docker run \
 		-d \

--- a/test/config/mariadb/bind.cnf
+++ b/test/config/mariadb/bind.cnf
@@ -1,0 +1,3 @@
+[mysqld]
+
+bind-address		= 0.0.0.0

--- a/test/share/tests/email-templates/external-spam-to-existing-user.txt
+++ b/test/share/tests/email-templates/external-spam-to-existing-user.txt
@@ -1,12 +1,13 @@
-HELO mail.example.com
-MAIL FROM: spam@example.com
+HELO mx.gmail.com
+MAIL FROM: spam@gmail.com
 RCPT TO: john.doe@domain.tld
 DATA
-From: Docker Mail Server <spam@example.com>
+From: Docker Mail Server <spam@gmail.com>
 To: Existing Local User <john.doe@domain.tld>
 Date: Sat, 28 Nov 2016 12:00:00 +0200
 Subject: Test Message
 This is a test mail.
+
 XJS*C4JDBQADN1.NSBN3*2IDNEN*GTUBE-STANDARD-ANTI-UBE-TEST-EMAIL*C.34X
 
 .

--- a/test/share/tests/email-templates/external-to-existing-alias-forward.txt
+++ b/test/share/tests/email-templates/external-to-existing-alias-forward.txt
@@ -1,8 +1,8 @@
-HELO mail.example.com
-MAIL FROM: user@example.com
+HELO mx.gmail.com
+MAIL FROM: user@gmail.com
 RCPT TO: postmaster@domain.tld
 DATA
-From: Docker Mail Server <user@example.com>
+From: Docker Mail Server <user@gmail.com>
 To: Existing Local Alias <postmaster@domain.tld>
 Date: Sat, 28 Nov 2016 12:00:00 +0200
 Subject: Test Message 2

--- a/test/share/tests/email-templates/external-to-existing-alias-group.txt
+++ b/test/share/tests/email-templates/external-to-existing-alias-group.txt
@@ -1,8 +1,8 @@
-HELO mail.example.com
-MAIL FROM: user@example.com
+HELO mx.gmail.com
+MAIL FROM: user@gmail.com
 RCPT TO: group@domain.tld
 DATA
-From: Docker Mail Server <user@example.com>
+From: Docker Mail Server <user@gmail.com>
 To: Existing Local Alias <group@domain.tld>
 Date: Sat, 28 Nov 2016 12:00:00 +0200
 Subject: Test Message

--- a/test/share/tests/email-templates/external-to-existing-alias.txt
+++ b/test/share/tests/email-templates/external-to-existing-alias.txt
@@ -1,8 +1,8 @@
-HELO mail.example.com
-MAIL FROM: user@example.com
+HELO mx.gmail.com
+MAIL FROM: user@gmail.com
 RCPT TO: hostmaster@domain.tld
 DATA
-From: Docker Mail Server <user@example.com>
+From: Docker Mail Server <user@gmail.com>
 To: Existing Local Alias <hostmaster@domain.tld>
 Date: Sat, 28 Nov 2016 12:00:00 +0200
 Subject: Test Message

--- a/test/share/tests/email-templates/external-to-existing-system-account.txt
+++ b/test/share/tests/email-templates/external-to-existing-system-account.txt
@@ -1,8 +1,8 @@
-HELO mail.example.com
-MAIL FROM: user@example.com
+HELO mx.gmail.com
+MAIL FROM: user@gmail.com
 RCPT TO: root
 DATA
-From: Docker Mail Server <user@example.com>
+From: Docker Mail Server <user@gmail.com>
 To: Local Account <root>
 Date: Sat, 28 Nov 2016 12:00:00 +0200
 Subject: Test Message

--- a/test/share/tests/email-templates/external-to-existing-user-spam-learning.txt
+++ b/test/share/tests/email-templates/external-to-existing-user-spam-learning.txt
@@ -1,8 +1,8 @@
-HELO mail.example.com
-MAIL FROM: user@example.com
+HELO mx.gmail.com
+MAIL FROM: user@gmail.com
 RCPT TO: sarah.connor@domain.tld
 DATA
-From: Docker Mail Server <user@example.com>
+From: Docker Mail Server <user@gmail.com>
 To: Existing Local User <sarah.connor@domain.tld>
 Date: Sat, 28 Nov 2016 12:00:00 +0200
 Subject: Test Message

--- a/test/share/tests/email-templates/external-to-existing-user.txt
+++ b/test/share/tests/email-templates/external-to-existing-user.txt
@@ -1,8 +1,8 @@
-HELO mail.example.com
-MAIL FROM: user@example.com
+HELO mx.gmail.com
+MAIL FROM: user@gmail.com
 RCPT TO: john.doe@domain.tld
 DATA
-From: Docker Mail Server <user@example.com>
+From: Docker Mail Server <user@gmail.com>
 To: Existing Local User <john.doe@domain.tld>
 Date: Sat, 28 Nov 2016 12:00:00 +0200
 Subject: Test Message

--- a/test/share/tests/email-templates/external-to-non-existing-user.txt
+++ b/test/share/tests/email-templates/external-to-non-existing-user.txt
@@ -1,8 +1,8 @@
-HELO mail.example.com
-MAIL FROM: user@example.com
+HELO mx.gmail.com
+MAIL FROM: user@gmail.com
 RCPT TO: ghost@domain.tld
 DATA
-From: Docker Mail Server <user@example.com>
+From: Docker Mail Server <user@gmail.com>
 To: Non Existing Local User <ghost@domain.tld>
 Date: Sat, 28 Nov 2016 12:00:00 +0200
 Subject: Test Message

--- a/test/share/tests/email-templates/external-to-valid-user-subaddress-with-default-separator.txt
+++ b/test/share/tests/email-templates/external-to-valid-user-subaddress-with-default-separator.txt
@@ -1,8 +1,8 @@
-HELO mail.example.com
-MAIL FROM: user@example.com
+HELO mx.gmail.com
+MAIL FROM: user@gmail.com
 RCPT TO: john.doe+subname@domain.tld
 DATA
-From: Docker Mail Server <user@example.com>
+From: Docker Mail Server <user@gmail.com>
 To: Existing Local User <john.doe+subname@domain.tld>
 Date: Sat, 28 Nov 2016 12:00:00 +0200
 Subject: Test Message

--- a/test/share/tests/email-templates/external-to-valid-user-subaddress.txt
+++ b/test/share/tests/email-templates/external-to-valid-user-subaddress.txt
@@ -1,8 +1,8 @@
-HELO mail.example.com
-MAIL FROM: user@example.com
+HELO mx.gmail.com
+MAIL FROM: user@gmail.com
 RCPT TO: john.doe:subname@domain.tld
 DATA
-From: Docker Mail Server <user@example.com>
+From: Docker Mail Server <user@gmail.com>
 To: Existing Local User <john.doe:subname@domain.tld>
 Date: Sat, 28 Nov 2016 12:00:00 +0200
 Subject: Test Message

--- a/test/share/tests/email-templates/external-virus-to-existing-user.txt
+++ b/test/share/tests/email-templates/external-virus-to-existing-user.txt
@@ -1,8 +1,8 @@
-HELO mail.example.com
-MAIL FROM: virus@example.com
+HELO mx.gmail.com
+MAIL FROM: virus@gmail.com
 RCPT TO: john.doe@domain.tld
 DATA
-From: Docker Mail Server <virus@example.com>
+From: Docker Mail Server <virus@gmail.com>
 To: Existing Local User <john.doe@domain.tld>
 Date: Sat, 28 Nov 2016 12:00:00 +0200
 Subject: Test Message

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -1067,19 +1067,19 @@ load 'test_helper/bats-assert/load'
 # rspamd
 
 @test "checking rspamd: spam filtered (default configuration)" {
-  run docker exec mailserver_default /bin/sh -c "grep -i 'Gtube pattern; from=<spam@example.com> to=<john.doe@domain.tld> ' /var/log/mail.log | wc -l"
+  run docker exec mailserver_default /bin/sh -c "grep -i 'Gtube pattern; from=<spam@gmail.com> to=<john.doe@domain.tld> ' /var/log/mail.log | wc -l"
   assert_success
   assert_output 1
 }
 
 @test "checking rspamd: spam filtered (reverse configuration)" {
-  run docker exec mailserver_reverse /bin/sh -c "grep -i 'Gtube pattern; from=<spam@example.com> to=<john.doe@domain.tld> ' /var/log/mail.log | wc -l"
+  run docker exec mailserver_reverse /bin/sh -c "grep -i 'Gtube pattern; from=<spam@gmail.com> to=<john.doe@domain.tld> ' /var/log/mail.log | wc -l"
   assert_success
   assert_output 1
 }
 
 @test "checking rspamd: spam filtered (ldap configuration)" {
-  run docker exec mailserver_ldap /bin/sh -c "grep -i 'Gtube pattern; from=<spam@example.com> to=<john.doe@domain.tld> ' /var/log/mail.log | wc -l"
+  run docker exec mailserver_ldap /bin/sh -c "grep -i 'Gtube pattern; from=<spam@gmail.com> to=<john.doe@domain.tld> ' /var/log/mail.log | wc -l"
   assert_success
   assert_output 1
 }


### PR DESCRIPTION
## Description

This PR is intended to make the tests pass again and addresses three problems:

* The mariadb image had, at least on my computer, an insane first startup time from arount 5 minutes. So when the tests started the database was not yet running and all mailserver_default tests thus failed. Fixed by using the mysql:5.7 docker image instead of mariadb.
* Both mariadb and mysql docker image do not bind to 0.0.0.0 anymore and thus are not reachable from outside. This was fixed by adding a config file and setting bind-address to 0.0.0.0
* The new postfix seems not to allow emails from example.com as it is missing an MX record. I changed them to @gmail.com for now but I am not sure if that is the best choice. Maybe someone has a better idea? I chose it because it exists and it's unlikely to land on any blacklist and thus interfering with other tests.

## Type of change

- [x] Test (adding missing tests or correcting existing ones)

## Status

- [x] Ready
- [ ] In development
- [ ] Hold

## Todo List
- maybe change test sender domain to something better

## How has this been tested ?

- internal tests
