### PR TITLE
implement single LDAP_URI instead of separate DB* variables for driver 'ldap'

### DIFF
--- a/rootfs/etc/dovecot/dovecot-ldap-master.conf.ext
+++ b/rootfs/etc/dovecot/dovecot-ldap-master.conf.ext
@@ -1,4 +1,4 @@
-hosts           = {{ .LDAP_URI }}
+uris           = {{ .LDAP_URI }}
 ldap_version    = 3
 {{ if eq .LDAP_BIND "true" }}
 auth_bind       = yes

--- a/rootfs/etc/dovecot/dovecot-ldap-master.conf.ext
+++ b/rootfs/etc/dovecot/dovecot-ldap-master.conf.ext
@@ -1,4 +1,4 @@
-hosts           = {{ .DBHOST }}:{{ .DBPORT }}
+hosts           = {{ .LDAP_URI }}
 ldap_version    = 3
 {{ if eq .LDAP_BIND "true" }}
 auth_bind       = yes

--- a/rootfs/etc/dovecot/dovecot-ldap.conf.ext
+++ b/rootfs/etc/dovecot/dovecot-ldap.conf.ext
@@ -1,4 +1,4 @@
-hosts           = {{ .LDAP_URI }}
+uris           = {{ .LDAP_URI }}
 ldap_version    = 3
 {{ if eq .LDAP_BIND "true" }}
 auth_bind       = yes

--- a/rootfs/etc/dovecot/dovecot-ldap.conf.ext
+++ b/rootfs/etc/dovecot/dovecot-ldap.conf.ext
@@ -1,4 +1,4 @@
-hosts           = {{ .DBHOST }}:{{ .DBPORT }}
+hosts           = {{ .LDAP_URI }}
 ldap_version    = 3
 {{ if eq .LDAP_BIND "true" }}
 auth_bind       = yes

--- a/rootfs/etc/postfix/ldap/sender-login-maps.cf
+++ b/rootfs/etc/postfix/ldap/sender-login-maps.cf
@@ -1,4 +1,4 @@
-server_host = {{ .DBHOST }}:{{ .DBPORT }}
+server_host = {{ .LDAP_URI }}
 version = 3
 
 {{ if eq .LDAP_TLS_ENABLED "true" }}

--- a/rootfs/etc/postfix/ldap/virtual-alias-maps.cf
+++ b/rootfs/etc/postfix/ldap/virtual-alias-maps.cf
@@ -1,4 +1,4 @@
-server_host = {{ .DBHOST }}:{{ .DBPORT }}
+server_host = {{ .LDAP_URI }}
 version = 3
 
 {{ if eq .LDAP_TLS_ENABLED "true" }}

--- a/rootfs/etc/postfix/ldap/virtual-forward-maps.cf
+++ b/rootfs/etc/postfix/ldap/virtual-forward-maps.cf
@@ -1,4 +1,4 @@
-server_host = {{ .DBHOST }}:{{ .DBPORT }}
+server_host = {{ .LDAP_URI }}
 version = 3
 
 {{ if eq .LDAP_TLS_ENABLED "true" }}

--- a/rootfs/etc/postfix/ldap/virtual-group-maps.cf
+++ b/rootfs/etc/postfix/ldap/virtual-group-maps.cf
@@ -1,4 +1,4 @@
-server_host = {{ .DBHOST }}:{{ .DBPORT }}
+server_host = {{ .LDAP_URI }}
 version = 3
 
 {{ if eq .LDAP_TLS_ENABLED "true" }}

--- a/rootfs/etc/postfix/ldap/virtual-mailbox-domains.cf
+++ b/rootfs/etc/postfix/ldap/virtual-mailbox-domains.cf
@@ -1,4 +1,4 @@
-server_host = {{ .DBHOST }}:{{ .DBPORT }}
+server_host = {{ .LDAP_URI }}
 version = 3
 
 {{ if eq .LDAP_TLS_ENABLED "true" }}

--- a/rootfs/etc/postfix/ldap/virtual-mailbox-maps.cf
+++ b/rootfs/etc/postfix/ldap/virtual-mailbox-maps.cf
@@ -1,4 +1,4 @@
-server_host = {{ .DBHOST }}:{{ .DBPORT }}
+server_host = {{ .LDAP_URI }}
 version = 3
 
 {{ if eq .LDAP_TLS_ENABLED "true" }}

--- a/rootfs/usr/local/bin/run.sh
+++ b/rootfs/usr/local/bin/run.sh
@@ -46,10 +46,14 @@ DISABLE_CLAMAV=${DISABLE_CLAMAV:-false} # --
 DISABLE_DNS_RESOLVER=${DISABLE_DNS_RESOLVER:-false} # --
 
 if [ "$DBDRIVER" = "ldap" ]; then
+  export LDAP_URI
   export LDAP_BIND
   export LDAP_BIND_DN
   export LDAP_BIND_PW
 
+  LDAP_URI=${LDAP_URI:-ldap://$DBHOST:$DBPORT}
+  # backward compatability with host name check
+  DBHOST=${DBHOST:-localhost}
   LDAP_BIND=${LDAP_BIND:-true}
   LDAP_BIND_DN=${LDAP_BIND_DN:-}
   LDAP_BIND_PW=$([ -f "$LDAP_BIND_PW" ] && cat "$LDAP_BIND_PW" || echo "${LDAP_BIND_PW:-}")


### PR DESCRIPTION
## Description

LDAP configurations commonly take a single URI instead of separate host and port values. Up until now, mailserver (mis-)uses DBHOST and DBPORT and precludes me from using a ldaps:// connection.

I suggest better splitting the sql and ldap 'modes' by implementing a LDAP_URI configuration variable. For backwards compatability, it can default to 'ldap://DBHOST:DBPORT'.

## Type of change
_Please delete options that are not relevant._

- [x] New feature (non-breaking change which adds functionality)

## Status

- [x] Ready

## Todo List

- [ ] Tests
- [ ] Documentation

## How has this been tested ?

My implementation.
