### PR TITLE
unify dns prefetching with additional hosts in PREFETCH_HOSTS

### DIFF
--- a/rootfs/usr/local/bin/run.sh
+++ b/rootfs/usr/local/bin/run.sh
@@ -92,11 +92,11 @@ if [[ "$REDIS_PORT" =~ [^[:digit:]] ]]; then
   REDIS_PORT=6379
 fi
 
-# DATABASES HOSTNAME CHECKING
+# PREFETCH HOSTS
 # We need to set these in the hosts file before Unbound takes over for DNS
 # ---------------------------------------------------------------------------------------------
-
-for onehost in $DBHOST $REDIS_HOST $PREFETCH_HOSTS; do
+PREFETCH_HOSTS=${PREFETCH_HOSTS:-$DBHOST $REDIS_HOST}
+for onehost in $PREFETCH_HOSTS; do
   grep -q "$onehost" /etc/hosts
 
   if [ $? -ne 0 ]; then


### PR DESCRIPTION
## Description

run.sh 'prefetches' certain hosts that might no longer be resolvable after Unbound takes over.
Currently this is hardcoded to the DBHOST and REDIS_HOST. If howerver, I want to add other
docker containers to my installation (like mailman), those need to be resolved as well.

I therefore propose to add a PREFETCH_HOSTS configuration variable that should include
all 'other' hosts to prefetch.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## Status

- [ ] Ready

## Todo List

- [ ] Documentation